### PR TITLE
fix: typo, README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A CLI toolbox for creating design systems.
 
-Visit the documentation [here](https://github.intuit.com/pages/design-systems/cli/#/).
+Visit the documentation [here](https://intuit.github.io/design-systems-cli/#).
 
 ## Contributing
 

--- a/packages/docs/src/getting-started.md
+++ b/packages/docs/src/getting-started.md
@@ -48,7 +48,7 @@ Now you are all set to develop your components locally!
 
 !> You **must** run sub-package scripts with `yarn`! Read more [here](/faq?id=why-arent-my-scripts-running).
 
-## Continuos Integration
+## Continuous Integration
 
 The default template for a `@design-systems/cli` comes with our preferred workflow for developing design systems.
 You can use other CI platforms and should use our circleCI config as a guide.


### PR DESCRIPTION
# What Changed

Small fixes. Double check the updated link is correct; the original link seems to be on a private network.

# Why

Todo:

- [ ] Add tests
- [ ] Add docs
