### PR TITLE
add clearer docs around custom storybook config

### DIFF
--- a/plugins/storybook/src/command.ts
+++ b/plugins/storybook/src/command.ts
@@ -39,7 +39,7 @@ const command: CliCommand = {
       It supports the following files:
 
       1. addons.js - configure addon loading. It acts exactly how a config.js works in storybook. Overrides the default addons.js
-      2. config.js - configure extra addons and load your stories. It acts exactly how a config.js works in storybook, just with all our default decorators and parameters
+      2. config.js - configure extra addons and load your stories. It acts exactly how a config.js works in storybook, just with all our default decorators and parameters. If using this you MUST load your stories or add this line "require('@design-systems/storybook/.storybook/defaultConfig');"
       3. presets.js - configure storybook presets. It acts exactly how a presets.js works in storybook
       4. webpack.config.js - configure extra webpack settings, works exactly like it does in storybook (ex: ({ config }) => config)
       5. dark-logo.png - Logo for the storybook when it's in dark mode


### PR DESCRIPTION
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.1-canary.9.240.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
