### PR TITLE
use correct changelog link

### DIFF
--- a/plugins/update/src/index.ts
+++ b/plugins/update/src/index.ts
@@ -62,7 +62,7 @@ async function getReleaseNotes(since: string) {
   logger.debug(`Getting release notes since v${since}`);
 
   const res = await fetch(
-    'https://github.com/raw/intuit/design-systems-cli/master/CHANGELOG.md'
+    'https://raw.githubusercontent.com/intuit/design-systems-cli/master/CHANGELOG.md'
   );
   const changelog = await res.text();
 


### PR DESCRIPTION
# What Changed

Update changelog url to public  github

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.3-canary.10.258.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
