### PR TITLE
merge user supplied args so they don't get overwritten

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "@design-systems/core": "link:../core",
     "@design-systems/load-config": "link:../load-config",
     "command-line-application": "0.9.6",
+    "deepmerge": "4.2.2",
     "dlv": "1.1.3",
     "dotenv": "8.2.0",
     "env-ci": "4.5.1",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,6 +8,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import get from 'dlv';
 import checkForUpdate from 'update-check';
+import merge from 'deepmerge';
 
 import { createLogger, setLogLevel } from '@design-systems/cli-utils';
 import { loadConfig, validateConfig } from '@design-systems/load-config';
@@ -106,7 +107,7 @@ export async function main() {
       ? args._command.join('.')
       : args._command;
 
-    return plugin.run({ ...global, ...get(config, commandPath, {}), ...args });
+    return plugin.run(merge.all([global, args, get(config, commandPath, {})]));
   }
 
   log.error(`No matching command found: ${commandName}`);


### PR DESCRIPTION
# What Changed

previously if someone supplied an arg that was an array it would get overwritten. Now it will merge it

# Why

ds.config.json build.ignore wasn't being respected


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.4-canary.11.274.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
