### PR TITLE
ignore building/copying mdx files

### DIFF
--- a/plugins/build/src/command.ts
+++ b/plugins/build/src/command.ts
@@ -7,6 +7,7 @@ export const defaults = {
   outputDirectory: 'dist',
   cssMain: 'main.css',
   ignore: [
+    './**/*.mdx',
     './**/__tests__/**',
     './**/__snapshots__/**',
     './**/*.+(stories|test).*',


### PR DESCRIPTION
# What Changed

ignore copying mdx files to dist

# Why

Storybook was picking these up in a separate project

1. have design-systems
2. have another design system that uses component from design system 1
3. error loading mdx file
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.4-canary.12.278.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
