### PR TITLE
Hash the classnames based on the contents of the css file + selector + package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+registry=https://registry.npmjs.com
 save-exact=true

--- a/plugins/build/package.json
+++ b/plugins/build/package.json
@@ -44,6 +44,7 @@
     "fs-extra": "8.1.0",
     "icss-utils": "4.1.1",
     "minimatch": "3.0.4",
+    "pkg-up": "3.1.0",
     "postcss": "7.0.26",
     "postcss-hexrgba": "2.0.0",
     "postcss-icss-selectors": "2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1496,7 +1496,7 @@
     minimist "^1.2.0"
 
 "@design-systems/build@link:plugins/build":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@babel/code-frame" "7.5.5"
     "@babel/core" "7.7.2"
@@ -1521,6 +1521,7 @@
     fs-extra "8.1.0"
     icss-utils "4.1.1"
     minimatch "3.0.4"
+    pkg-up "3.1.0"
     postcss "7.0.26"
     postcss-hexrgba "2.0.0"
     postcss-icss-selectors "2.0.3"
@@ -1536,7 +1537,7 @@
     typescript "3.7.2"
 
 "@design-systems/bundle@link:plugins/bundle":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/build" "link:plugins/build"
     "@design-systems/cli-utils" "link:packages/cli-utils"
@@ -1554,7 +1555,7 @@
     webpack "4.41.2"
 
 "@design-systems/clean@link:plugins/clean":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/plugin" "link:packages/plugin"
@@ -1563,7 +1564,7 @@
     tslib "1.10.0"
 
 "@design-systems/cli-utils@link:packages/cli-utils":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     find-up "4.1.0"
     npm-which "3.0.1"
@@ -1573,7 +1574,7 @@
     webpack "4.41.2"
 
 "@design-systems/core@link:packages/core":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/build" "link:plugins/build"
     "@design-systems/bundle" "link:plugins/bundle"
@@ -1593,7 +1594,7 @@
     tslib "1.10.0"
 
 "@design-systems/create-command@link:plugins/create-command":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/create" "link:packages/create"
@@ -1611,10 +1612,10 @@
     tslib "1.10.0"
 
 "@design-systems/create@link:packages/create":
-  version "0.74.9"
+  version "0.74.13"
 
 "@design-systems/dev@link:plugins/dev":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/plugin" "link:packages/plugin"
@@ -1624,7 +1625,7 @@
     tslib "1.10.0"
 
 "@design-systems/eslint-config@link:packages/eslint-config":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@typescript-eslint/eslint-plugin" "2.8.0"
@@ -1647,7 +1648,7 @@
     tslib "1.10.0"
 
 "@design-systems/lint@link:plugins/lint":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/eslint-config" "link:packages/eslint-config"
@@ -1664,7 +1665,7 @@
     tslib "1.10.0"
 
 "@design-systems/load-config@link:packages/load-config":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/core" "link:packages/core"
     "@design-systems/plugin" "link:packages/plugin"
@@ -1678,7 +1679,7 @@
     tslib "1.10.0"
 
 "@design-systems/playroom@link:plugins/playroom":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@babel/core" "7.7.2"
     "@babel/register" "7.7.0"
@@ -1697,14 +1698,14 @@
     webpack "4.41.2"
 
 "@design-systems/plugin@link:packages/plugin":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     command-line-application "0.9.5"
     tslib "1.10.0"
     utility-types "3.10.0"
 
 "@design-systems/proof@link:plugins/proof":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@babel/core" "7.7.2"
     "@babel/plugin-transform-runtime" "7.6.2"
@@ -1723,7 +1724,7 @@
     tslib "1.10.0"
 
 "@design-systems/size@link:plugins/size":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/plugin" "link:packages/plugin"
@@ -1753,7 +1754,7 @@
     webpack-sources "1.4.3"
 
 "@design-systems/storybook@link:plugins/storybook":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@babel/core" "7.7.2"
     "@design-systems/build" "link:plugins/build"
@@ -1787,7 +1788,7 @@
     webpack-filter-warnings-plugin "1.2.1"
 
 "@design-systems/stylelint-config@link:packages/stylelint-config":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     stylelint-a11y "1.2.2"
     stylelint-config-css-modules "2.1.0"
@@ -1801,7 +1802,7 @@
     tslib "1.10.0"
 
 "@design-systems/test@link:plugins/test":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@babel/core" "7.7.2"
     "@design-systems/build" "link:plugins/build"
@@ -1821,7 +1822,7 @@
     tslib "1.10.0"
 
 "@design-systems/update@link:plugins/update":
-  version "0.74.9"
+  version "0.74.13"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/plugin" "link:packages/plugin"
@@ -14786,6 +14787,13 @@ pkg-up@2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
+
+pkg-up@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
 
 playroom@hipstersmoothie/playroom#snippets:
   version "0.0.0-semantically-released"


### PR DESCRIPTION
# What Changed

Classnames were calculated based off of the contents of the css selector. 
If multiple people use different versions of the same design-system component in the same app, there's a chance they will collide -- and any specificity introduced by the order in the css file can be lost. 

# Why

🐛 Bugs 🐛 

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.0.5-canary.13.299.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
