### PR TITLE
add size option for private registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           at: ~/design-systems-cli
       - run:
           name: Check PR for semantic version label
-          command: auto pr-check --pr $CHANGE_ID --url $CIRCLE_BUILD_URL
+          command: yarn auto pr-check --pr $CHANGE_ID --url $CIRCLE_BUILD_URL
 
   release:
     <<: *defaults

--- a/plugins/lint/src/index.ts
+++ b/plugins/lint/src/index.ts
@@ -280,7 +280,7 @@ export default class LintPlugin implements Plugin<LintArgs> {
           ...result,
           warnings: [
             ...result.warnings,
-            ...disables.ranges.map((range: any) => ({
+            ...disables.ranges.map(range => ({
               rule: range.unusedRule,
               severity: 'warning' as stylelint.Severity,
               text: 'Needless stylint-disable',

--- a/plugins/size/src/command.ts
+++ b/plugins/size/src/command.ts
@@ -67,6 +67,12 @@ const command: CliCommand = {
       config: true
     },
     {
+      name: 'registry',
+      type: String,
+      description: 'The registry to install packages from',
+      config: true
+    },
+    {
       name: 'comment',
       type: Boolean,
       description:

--- a/plugins/size/src/index.ts
+++ b/plugins/size/src/index.ts
@@ -13,7 +13,7 @@ import fs from 'fs-extra';
 import Commently from 'commently';
 import getExports from '@royriojas/get-exports-from-file';
 import changeCase from 'change-case';
-import InjectPlugin, { registry } from 'webpack-inject-plugin';
+import InjectPlugin from 'webpack-inject-plugin';
 
 import { table as cliTable } from 'table';
 import markdownTable from 'markdown-table';
@@ -463,7 +463,6 @@ async function getSizes(options: GetSizesOptions & CommonOptions) {
 
     logger.debug(`Installing: ${options.name}`);
 
-    console.log({options})
     if (options.registry) {
       execSync(`yarn add ${options.name} --registry ${options.registry}`, execOptions);
     } else {


### PR DESCRIPTION
# What Changed

Can now run size checks against a private registry

# Why

The design-system I develop in private.

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.1.0-canary.15.332.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
