### PR TITLE
update some thing for storybook 5.3

### DIFF
--- a/plugins/storybook/.storybook/addons-preset.js
+++ b/plugins/storybook/.storybook/addons-preset.js
@@ -2,7 +2,7 @@ const { getMonorepoRoot } = require('@design-systems/cli-utils');
 const fs = require('fs');
 const path = require('path');
 
-function addons(entry = []) {
+function managerEntries(entry = []) {
   const projectRoot = getMonorepoRoot();
   const hasAddons =
     fs.existsSync(path.join(projectRoot, '.storybook/addons.js')) ||
@@ -32,4 +32,4 @@ function addons(entry = []) {
   return newAddons;
 }
 
-module.exports = { addons };
+module.exports = { managerEntries };

--- a/plugins/storybook/.storybook/webpack.config.js
+++ b/plugins/storybook/.storybook/webpack.config.js
@@ -87,10 +87,6 @@ async function addCss(config) {
 
   // Generate normal source map through css loaders
   cssLoader.options.sourceMap = true;
-  cssRule.use[0] = {
-    loader: cssRule.use[0],
-    options: { sourceMap: true }
-  };
   cssLoader.options.importLoaders = 1;
 
   // Must come before modules is set to true


### PR DESCRIPTION
# What Changed

preset definitions change in 5.3 + style-loader update renders config option obsolete

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.2.1-canary.103.1260.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
