### PR TITLE
Add install step to getting started

### DIFF
--- a/packages/docs/src/getting-started.md
+++ b/packages/docs/src/getting-started.md
@@ -29,6 +29,7 @@ This command will walk you through the initial set up of your system.
 After you are done `cd` to the generated folder and start adding components with the following command:
 
 ```sh
+yarn # install dependencies
 yarn run create --name component
 ```
 


### PR DESCRIPTION
# What Changed

Adding install step to getting started.

# Why

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.2.6-canary.134.1500.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
