### PR TITLE
Support Non-Monorepo Package Root

### DIFF
--- a/packages/cli-utils/src/utils/get-repo-root.ts
+++ b/packages/cli-utils/src/utils/get-repo-root.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import findUp from 'find-up';
+
+/** Determine the directory of the repo */
+const getRepoRoot = (cwd: string = process.cwd()) => {
+  try {
+    const repoRoot = findUp.sync('package.json', {
+      cwd
+    });
+
+    if (!repoRoot) {
+      return '';
+    }
+
+    return path.dirname(repoRoot);
+  } catch (error) {
+    return '';
+  }
+};
+
+export default getRepoRoot;

--- a/packages/cli-utils/src/utils/index.ts
+++ b/packages/cli-utils/src/utils/index.ts
@@ -1,5 +1,5 @@
 export { default as lerna } from './lerna';
-export { default as getRepoRoot } from './get-monorepo-root';
+export { default as getRepoRoot } from './get-repo-root';
 export { default as getMonorepoRoot } from './get-monorepo-root';
 export { default as monorepoName } from './monorepo-name';
 export { default as loadUserWebpackConfig } from './load-user-webpack-config';

--- a/packages/cli-utils/src/utils/index.ts
+++ b/packages/cli-utils/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { default as lerna } from './lerna';
+export { default as getRepoRoot } from './get-monorepo-root';
 export { default as getMonorepoRoot } from './get-monorepo-root';
 export { default as monorepoName } from './monorepo-name';
 export { default as loadUserWebpackConfig } from './load-user-webpack-config';

--- a/plugins/bundle/src/index.ts
+++ b/plugins/bundle/src/index.ts
@@ -1,4 +1,4 @@
-import { createLogger, getMonorepoRoot } from '@design-systems/cli-utils';
+import { createLogger, getMonorepoRoot, getRepoRoot } from '@design-systems/cli-utils';
 import { Plugin } from '@design-systems/plugin';
 import fs from 'fs';
 import path from 'path';
@@ -33,7 +33,7 @@ function pack(config: webpack.Configuration): Promise<webpack.Stats> {
 async function getConfig(
   options: ConfigOptions
 ): Promise<webpack.Configuration> {
-  const root = getMonorepoRoot();
+  const root = getMonorepoRoot() || getRepoRoot();
   const customConfigPath = path.join(root, 'webpack.config.js');
   let config = baseWebpackConfig;
   if (fs.existsSync(customConfigPath)) {


### PR DESCRIPTION
# What Changed

What if it's not mono repo?

# Why

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.3.1-canary.136.1674.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
