### PR TITLE
changing log level from debug to info for sauce url

### DIFF
--- a/plugins/proof/proof.config.base.js
+++ b/plugins/proof/proof.config.base.js
@@ -27,7 +27,7 @@ class SauceLogger {
   apply(proof) {
     proof.hooks.browserFactory.tap('sauce', browserFactory => {
       browserFactory.hooks.capabilities.tap('sauce', capabilities => {
-        logger.debug(chalk.gray('Sauce Labs URL'), capabilities.resultsUrl);
+        logger.info(chalk.gray('Sauce Labs URL'), capabilities.resultsUrl);
         logger.debug(chalk.gray('TEP URL'), capabilities.sessionDashboardURL);
       });
     });


### PR DESCRIPTION
# What Changed
Changing the log level for Sauce url from debug to info

# Why
The sauce URL is only visible when we provide --vv option.  This add ton of verbose logging.  If I want to have a crisp log and still get the link to sauce URL, I have to change the log level from debug to info.

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.3.1-canary.139.1774.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
