### PR TITLE
renaming from TEP to Connection

### DIFF
--- a/plugins/proof/proof.config.base.js
+++ b/plugins/proof/proof.config.base.js
@@ -28,7 +28,7 @@ class SauceLogger {
     proof.hooks.browserFactory.tap('sauce', browserFactory => {
       browserFactory.hooks.capabilities.tap('sauce', capabilities => {
         logger.info(chalk.gray('Sauce Labs URL'), capabilities.resultsUrl);
-        logger.debug(chalk.gray('TEP URL'), capabilities.sessionDashboardURL);
+        logger.debug(chalk.gray('Connection URL'), capabilities.sessionDashboardURL);
       });
     });
   }


### PR DESCRIPTION
# What Changed

# Why

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.4.1-canary.140.1799.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
