### PR TITLE
fix resolving files other than main import

### DIFF
--- a/packages/babel-plugin-include-styles/package.json
+++ b/packages/babel-plugin-include-styles/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@babel/traverse": "7.8.3",
+    "find-up": "4.1.0",
     "tslib": "1.10.0"
   },
   "devDependencies": {

--- a/packages/babel-plugin-include-styles/src/__tests__/index.test.ts
+++ b/packages/babel-plugin-include-styles/src/__tests__/index.test.ts
@@ -1,8 +1,13 @@
 import { transform } from './helpers/utils';
 import exists from '../exists';
+import resolvePackage from '../resolve-package';
 
 jest.mock('../exists.ts');
+jest.mock('../resolve-package.ts');
 jest.mock('@cgds/test/package.json', () => ({}), { virtual: true });
+
+const resolveSpy = resolvePackage as jest.Mock
+resolveSpy.mockReturnValue('@cgds/test/package.json')
 
 test('should not change css import', () => {
   const source = 'import "@cgds/test/dist/main.css";';
@@ -48,4 +53,18 @@ test("shouldn't add css import if file doesn't exist", () => {
   exists.mockReturnValueOnce(false);
   const source = 'import Test from "@cgds/test";';
   expect(transform(source)).toBe('import Test from "@cgds/test";');
+});
+
+test("should work for other css imports", () => {
+  // @ts-ignore
+  exists.mockReturnValueOnce(false);
+  const source = 'import "@cgds/some/dist/other.css";';
+  expect(transform(source)).toBe(source);
+});
+
+test("should not fail for deeper imports", () => {
+  // @ts-ignore
+  exists.mockReturnValueOnce(false);
+  const source = 'import "@cgds/some/dist/other.js";';
+  expect(transform(source)).toBe(source);
 });

--- a/packages/babel-plugin-include-styles/src/__tests__/with-deps.test.ts
+++ b/packages/babel-plugin-include-styles/src/__tests__/with-deps.test.ts
@@ -1,27 +1,39 @@
 import { transform } from './helpers/utils';
 import exists from '../exists';
+import resolvePackage from '../resolve-package';
 
 jest.mock('../exists.ts');
-jest.mock('@cgds/last/package.json', () => ({}), { virtual: true });
+jest.mock('../resolve-package.ts');
+
+jest.mock('@cgds/last/package.json', () => ({ name: '@cgds/last' }), {
+  virtual: true
+});
+
 jest.mock(
   '@cgds/other/package.json',
-  () => ({ dependencies: { '@cgds/last': '1.0.0' } }),
+  () => ({ name: '@cgds/other', dependencies: { '@cgds/last': '1.0.0' } }),
   { virtual: true }
 );
+
 jest.mock(
   '@cgds/test/package.json',
-  () => ({ dependencies: { '@cgds/other': '1.0.0' } }),
+  () => ({ name: '@cgds/test', dependencies: { '@cgds/other': '1.0.0' } }),
   { virtual: true }
 );
+
+const resolveSpy = resolvePackage as jest.Mock;
 
 test("should add dependency's css", () => {
   // @ts-ignore
   exists.mockReturnValueOnce(true);
+  resolveSpy.mockReturnValueOnce('@cgds/test/package.json');
   // @cgds/other doesn't have css itself, but import components that do have css
   // @ts-ignore
   exists.mockReturnValueOnce(false);
+  resolveSpy.mockReturnValueOnce('@cgds/other/package.json');
   // @ts-ignore
   exists.mockReturnValueOnce(true);
+  resolveSpy.mockReturnValueOnce('@cgds/last/package.json');
 
   const source = 'import Test from "@cgds/test";';
   expect(transform(source)).toBe(

--- a/packages/babel-plugin-include-styles/src/resolve-package.ts
+++ b/packages/babel-plugin-include-styles/src/resolve-package.ts
@@ -1,0 +1,8 @@
+import findUp from 'find-up';
+
+/** Get the package json for a require statement */
+const resolvePackage = (name: string) => findUp.sync('package.json', {
+  cwd: require.resolve(name)
+});
+
+export default resolvePackage;


### PR DESCRIPTION
# What Changed

there were bugs with the auto-importer if you imported anything other than the package name

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.4.4-canary.161.2407.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
