### PR TITLE
Move story/snippet/test type-checking to respective plugins

### DIFF
--- a/plugins/build/src/command.ts
+++ b/plugins/build/src/command.ts
@@ -7,10 +7,10 @@ export const defaults = {
   outputDirectory: 'dist',
   cssMain: 'main.css',
   ignore: [
-    './**/*.+(md|mdx)',
-    './**/__tests__/**',
-    './**/__snapshots__/**',
-    './**/*.+(stories|test).*'
+    '**/*.+(md|mdx)',
+    '**/__tests__/**',
+    '**/__snapshots__/**',
+    '**/*.+(stories|test|snippet).*'
   ]
 };
 

--- a/plugins/build/src/typescript.ts
+++ b/plugins/build/src/typescript.ts
@@ -172,6 +172,8 @@ export default class TypescriptCompiler {
     const ignoredPatterns = Array.isArray(this.buildArgs.ignore)
       ? this.buildArgs.ignore
       : [this.buildArgs.ignore];
+    
+    /** Determine if a file should not be type-checked or emitted */
     const isIgnored = (file: string) =>
       ignoredPatterns.some(pattern => minimatch(file, pattern));
 
@@ -193,7 +195,7 @@ export default class TypescriptCompiler {
               
               if (isIgnored(fileName)) {
                 // Don't type check stories
-                content = '// @ts-nocheck\n' + content;
+                content = `// @ts-nocheck\n${content}`;
               }
 
               return content;

--- a/plugins/dev/package.json
+++ b/plugins/dev/package.json
@@ -22,6 +22,7 @@
     "@design-systems/cli-utils": "link:../../packages/cli-utils",
     "@design-systems/plugin": "link:../../packages/plugin",
     "chokidar": "3.3.1",
+    "dedent": "0.7.0",
     "find-package-json": "1.2.0",
     "resolve-cwd": "3.0.0",
     "tslib": "1.11.1"

--- a/plugins/dev/src/command.ts
+++ b/plugins/dev/src/command.ts
@@ -4,7 +4,33 @@ const command: CliCommand = {
   name: 'dev',
   description:
     'Builds a component, any dependent component in the same monorepo, and starts storybook for just the component.',
-  examples: ['ds dev']
+  examples: ['ds dev'],
+  footer: [
+    {
+      header: 'Solving Circular Dependencies for Stories',
+      content:
+        dedent`
+          In a monorepo full of components you might get circlular dependencies when writing rich component documentation.
+
+          To get around this problem "ds-cli" supports a special package.json property to track these dependenceies called "storyDependencies".
+          Because it's not an official part of the package.json "lerna" won't use these dependencies to find the build order.
+
+          The "dev" command will build these dependencies while running.
+        `
+    },
+    {
+      code: true,
+      content: dedent`
+        \`\`\`json
+        {
+          "storyDependencies": {
+            "@my-system/field": "link:../Field"
+          }
+        }
+        \`\`\`
+      `
+    }
+  ]
 };
 
 export default command;

--- a/plugins/dev/src/command.ts
+++ b/plugins/dev/src/command.ts
@@ -1,4 +1,5 @@
 import { CliCommand } from '@design-systems/plugin';
+import dedent from 'dedent';
 
 const command: CliCommand = {
   name: 'dev',

--- a/plugins/dev/src/index.ts
+++ b/plugins/dev/src/index.ts
@@ -48,7 +48,9 @@ const createDepsSet = (
 
   const subDeps = [
     ...filterDeps(monorepo, packageJson, 'dependencies'),
-    ...filterDeps(monorepo, packageJson, 'devDependencies')
+    ...filterDeps(monorepo, packageJson, 'devDependencies'),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...filterDeps(monorepo, packageJson, 'storyDependencies' as any)
   ];
 
   subDeps.forEach(dep => {

--- a/plugins/playroom/package.json
+++ b/plugins/playroom/package.json
@@ -28,6 +28,7 @@
     "css-loader": "3.4.2",
     "fast-glob": "3.2.2",
     "file-loader": "5.0.2",
+    "fork-ts-checker-webpack-plugin": "4.1.3",
     "fs-extra": "8.1.0",
     "playroom": "0.16.1",
     "react-element-to-jsx-string": "14.3.1",

--- a/plugins/playroom/src/playroom.config.ts
+++ b/plugins/playroom/src/playroom.config.ts
@@ -3,6 +3,7 @@
 // @ts-ignore
 import babelConfig from '@design-systems/build/babel.config';
 import { loadUserWebpackConfig } from '@design-systems/cli-utils';
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 const config = babelConfig({ env: () => '' });
 
@@ -58,6 +59,14 @@ export default async ({
       }
     },
     'playroom'
+  );
+
+  config.plugins.push(
+    new ForkTsCheckerWebpackPlugin({
+      formatter: 'codeframe',
+      checkSyntacticErrors: true,
+      reportFiles: ['**/*.snippet.tsx', '!**/node_modules/**']
+    })
   );
 
   return {

--- a/plugins/storybook/.storybook/webpack.config.js
+++ b/plugins/storybook/.storybook/webpack.config.js
@@ -10,6 +10,7 @@ const { getPostCssConfig } = require('@design-systems/build');
 const githubUrlToObject = require('github-url-to-object');
 const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
 const BABEL_CONFIG = require.resolve('@design-systems/build/babel.config');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 function findBabelRules(config) {
   return config.module.rules.filter(rule => {
@@ -79,6 +80,14 @@ function addTypescript(config) {
       }
     ]
   });
+
+  config.plugins.push(
+    new ForkTsCheckerWebpackPlugin({
+      formatter: 'codeframe',
+      checkSyntacticErrors: true,
+      reportFiles: ['**/*.stories.tsx', '!**/node_modules/**']
+    })
+  );
 }
 
 async function addCss(config) {

--- a/plugins/storybook/package.json
+++ b/plugins/storybook/package.json
@@ -39,6 +39,7 @@
     "babel-loader": "8.1.0",
     "core-js": "3.6.4",
     "dedent": "0.7.0",
+    "fork-ts-checker-webpack-plugin": "4.1.3",
     "get-port": "5.1.1",
     "github-url-to-object": "4.0.4",
     "react-docgen-typescript-loader": "3.6.0",

--- a/plugins/storybook/src/index.ts
+++ b/plugins/storybook/src/index.ts
@@ -72,10 +72,10 @@ export default class StorybookPlugin implements Plugin<StorybookArgs> {
           configDir: path.join(__dirname, '../.storybook'),
           ci: 'ci' in args && args.ci
         });
-        
       }
     } catch (e) {
-      this.logger.error(e);
+      this.logger.error('Failed to build storybook');
+      this.logger.trace(e)
       process.exit(1);
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1915,7 +1915,7 @@
     minimist "^1.2.0"
 
 "@design-systems/build@link:plugins/build":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@babel/code-frame" "7.8.3"
     "@babel/core" "7.9.0"
@@ -1956,7 +1956,7 @@
     typescript "3.8.3"
 
 "@design-systems/bundle@link:plugins/bundle":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/build" "link:plugins/build"
     "@design-systems/cli-utils" "link:packages/cli-utils"
@@ -1974,7 +1974,7 @@
     webpack "4.41.5"
 
 "@design-systems/clean@link:plugins/clean":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/plugin" "link:packages/plugin"
@@ -1983,7 +1983,7 @@
     tslib "1.11.1"
 
 "@design-systems/cli-utils@link:packages/cli-utils":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     find-up "4.1.0"
     npm-which "3.0.1"
@@ -1993,7 +1993,7 @@
     webpack "4.41.5"
 
 "@design-systems/core@link:packages/core":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/build" "link:plugins/build"
     "@design-systems/bundle" "link:plugins/bundle"
@@ -2013,7 +2013,7 @@
     tslib "1.11.1"
 
 "@design-systems/create-command@link:plugins/create-command":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/create" "link:packages/create"
@@ -2032,10 +2032,10 @@
     tslib "1.11.1"
 
 "@design-systems/create@link:packages/create":
-  version "1.4.15"
+  version "1.5.1"
 
 "@design-systems/dev@link:plugins/dev":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/plugin" "link:packages/plugin"
@@ -2045,7 +2045,7 @@
     tslib "1.11.1"
 
 "@design-systems/eslint-config@link:packages/eslint-config":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@typescript-eslint/eslint-plugin" "2.17.0"
@@ -2068,7 +2068,7 @@
     tslib "1.11.1"
 
 "@design-systems/lint@link:plugins/lint":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/eslint-config" "link:packages/eslint-config"
@@ -2085,7 +2085,7 @@
     tslib "1.11.1"
 
 "@design-systems/load-config@link:packages/load-config":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/core" "link:packages/core"
     "@design-systems/plugin" "link:packages/plugin"
@@ -2099,7 +2099,7 @@
     tslib "1.11.1"
 
 "@design-systems/playroom@link:plugins/playroom":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/register" "7.9.0"
@@ -2118,14 +2118,14 @@
     webpack "4.41.5"
 
 "@design-systems/plugin@link:packages/plugin":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     command-line-application "0.9.6"
     tslib "1.11.1"
     utility-types "3.10.0"
 
 "@design-systems/proof@link:plugins/proof":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/plugin-transform-runtime" "7.9.0"
@@ -2143,7 +2143,7 @@
     tslib "1.11.1"
 
 "@design-systems/size@link:plugins/size":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/plugin" "link:packages/plugin"
@@ -2173,7 +2173,7 @@
     webpack-sources "1.4.3"
 
 "@design-systems/storybook@link:plugins/storybook":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@babel/core" "7.9.0"
     "@design-systems/build" "link:plugins/build"
@@ -2208,7 +2208,7 @@
     webpack-filter-warnings-plugin "1.2.1"
 
 "@design-systems/stylelint-config@link:packages/stylelint-config":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     stylelint-a11y "1.2.3"
     stylelint-config-css-modules "2.2.0"
@@ -2222,7 +2222,7 @@
     tslib "1.11.1"
 
 "@design-systems/test@link:plugins/test":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@babel/core" "7.9.0"
     "@design-systems/build" "link:plugins/build"
@@ -2242,7 +2242,7 @@
     tslib "1.11.1"
 
 "@design-systems/update@link:plugins/update":
-  version "1.4.15"
+  version "1.5.1"
   dependencies:
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/plugin" "link:packages/plugin"
@@ -10422,6 +10422,19 @@ fork-ts-checker-webpack-plugin@1.5.0:
     babel-code-frame "^6.22.0"
     chalk "^2.4.1"
     chokidar "^2.0.4"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    semver "^5.6.0"
+    tapable "^1.0.0"
+    worker-rpc "^0.1.0"
+
+fork-ts-checker-webpack-plugin@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-4.1.3.tgz#306f1566fc1c916816830b3de4e53da8d6d6a9e2"
+  integrity sha512-ErA8cFsPfAIOx2UFoRlMraGVB1Ye3bXQTdNW6lmeKQDuNnkORqJmA9bcReNxJj5kVHeKkKcNZv3f6PMyeugO+w==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
     micromatch "^3.1.10"
     minimatch "^3.0.4"
     semver "^5.6.0"


### PR DESCRIPTION
# What Changed

Previously the `build` command was also building the stories and snippets of a component.

# Why

Because `ds-cli` has monorepo based design systems we can get into circular dependency problems.

For example if a `Card` component depends on `Icon` but `Icon` also has stories/docs that use `Card` we have a problem. To get around this we defer the type-checking of files that may use other component as devdep (story, snippet) to the plugin that handles that type of file. 

This means that when we go to build the storybook all components will have already been built and the stories will be able to be type-checked easily.

`tldr;` This enables stories to be a bit more flexible and use whatever components they need, regardless of circular deps


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.0-canary.214.4494.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @design-systems/babel-plugin-include-styles@1.7.0-canary.214.4494.0
  npm install @design-systems/cli-utils@1.7.0-canary.214.4494.0
  npm install @design-systems/cli@1.7.0-canary.214.4494.0
  npm install @design-systems/core@1.7.0-canary.214.4494.0
  npm install @design-systems/create@1.7.0-canary.214.4494.0
  npm install @design-systems/eslint-config@1.7.0-canary.214.4494.0
  npm install @design-systems/load-config@1.7.0-canary.214.4494.0
  npm install @design-systems/plugin@1.7.0-canary.214.4494.0
  npm install @design-systems/stylelint-config@1.7.0-canary.214.4494.0
  npm install @design-systems/build@1.7.0-canary.214.4494.0
  npm install @design-systems/bundle@1.7.0-canary.214.4494.0
  npm install @design-systems/clean@1.7.0-canary.214.4494.0
  npm install @design-systems/create-command@1.7.0-canary.214.4494.0
  npm install @design-systems/dev@1.7.0-canary.214.4494.0
  npm install @design-systems/lint@1.7.0-canary.214.4494.0
  npm install @design-systems/playroom@1.7.0-canary.214.4494.0
  npm install @design-systems/proof@1.7.0-canary.214.4494.0
  npm install @design-systems/size@1.7.0-canary.214.4494.0
  npm install @design-systems/storybook@1.7.0-canary.214.4494.0
  npm install @design-systems/test@1.7.0-canary.214.4494.0
  npm install @design-systems/update@1.7.0-canary.214.4494.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@1.7.0-canary.214.4494.0
  yarn add @design-systems/cli-utils@1.7.0-canary.214.4494.0
  yarn add @design-systems/cli@1.7.0-canary.214.4494.0
  yarn add @design-systems/core@1.7.0-canary.214.4494.0
  yarn add @design-systems/create@1.7.0-canary.214.4494.0
  yarn add @design-systems/eslint-config@1.7.0-canary.214.4494.0
  yarn add @design-systems/load-config@1.7.0-canary.214.4494.0
  yarn add @design-systems/plugin@1.7.0-canary.214.4494.0
  yarn add @design-systems/stylelint-config@1.7.0-canary.214.4494.0
  yarn add @design-systems/build@1.7.0-canary.214.4494.0
  yarn add @design-systems/bundle@1.7.0-canary.214.4494.0
  yarn add @design-systems/clean@1.7.0-canary.214.4494.0
  yarn add @design-systems/create-command@1.7.0-canary.214.4494.0
  yarn add @design-systems/dev@1.7.0-canary.214.4494.0
  yarn add @design-systems/lint@1.7.0-canary.214.4494.0
  yarn add @design-systems/playroom@1.7.0-canary.214.4494.0
  yarn add @design-systems/proof@1.7.0-canary.214.4494.0
  yarn add @design-systems/size@1.7.0-canary.214.4494.0
  yarn add @design-systems/storybook@1.7.0-canary.214.4494.0
  yarn add @design-systems/test@1.7.0-canary.214.4494.0
  yarn add @design-systems/update@1.7.0-canary.214.4494.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
