### PR TITLE
fix build --watch building ignored files

### DIFF
--- a/plugins/build/src/index.ts
+++ b/plugins/build/src/index.ts
@@ -270,8 +270,7 @@ export default class BuildPlugin implements Plugin<BuildArgs> {
     }
   };
 
-  isIgnored = (filename: string) =>
-    match(`./${filename}`, this.buildArgs.ignore);
+  isIgnored = (filename: string) => match(filename, this.buildArgs.ignore);
 
   watch = async () => {
     const watcher = fileWatcher(
@@ -306,7 +305,7 @@ export default class BuildPlugin implements Plugin<BuildArgs> {
     this.buildArgs = { ...this.buildArgs, ...args };
     this.typescriptCompiler = new TypescriptCompiler(this.buildArgs);
     const startTime = Date.now();
-    const { watch, outputDirectory, ignore } = this.buildArgs;
+    const { watch, outputDirectory } = this.buildArgs;
 
     // Since watching happens across everything in parallel,
     // leave any old build there for now
@@ -318,7 +317,7 @@ export default class BuildPlugin implements Plugin<BuildArgs> {
 
     // Kick off all of the transforms in parallel
     const transformed = files
-      .map(nextFile => !match(nextFile, ignore) && this.transformFile(nextFile))
+      .map(nextFile => !this.isIgnored(nextFile) && this.transformFile(nextFile))
       .filter(
         (i): i is Promise<undefined | SuccessState> => typeof i !== 'boolean'
       );


### PR DESCRIPTION
# What Changed

When rebuilding files we weren't properly matching the ignore globs

# Why

Fixes a bug where stories/mdx would be built during watch mode



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.1-canary.246.5023.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @design-systems/babel-plugin-include-styles@1.7.1-canary.246.5023.0
  npm install @design-systems/cli-utils@1.7.1-canary.246.5023.0
  npm install @design-systems/cli@1.7.1-canary.246.5023.0
  npm install @design-systems/core@1.7.1-canary.246.5023.0
  npm install @design-systems/create@1.7.1-canary.246.5023.0
  npm install @design-systems/eslint-config@1.7.1-canary.246.5023.0
  npm install @design-systems/load-config@1.7.1-canary.246.5023.0
  npm install @design-systems/plugin@1.7.1-canary.246.5023.0
  npm install @design-systems/stylelint-config@1.7.1-canary.246.5023.0
  npm install @design-systems/build@1.7.1-canary.246.5023.0
  npm install @design-systems/bundle@1.7.1-canary.246.5023.0
  npm install @design-systems/clean@1.7.1-canary.246.5023.0
  npm install @design-systems/create-command@1.7.1-canary.246.5023.0
  npm install @design-systems/dev@1.7.1-canary.246.5023.0
  npm install @design-systems/lint@1.7.1-canary.246.5023.0
  npm install @design-systems/playroom@1.7.1-canary.246.5023.0
  npm install @design-systems/proof@1.7.1-canary.246.5023.0
  npm install @design-systems/size@1.7.1-canary.246.5023.0
  npm install @design-systems/storybook@1.7.1-canary.246.5023.0
  npm install @design-systems/test@1.7.1-canary.246.5023.0
  npm install @design-systems/update@1.7.1-canary.246.5023.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@1.7.1-canary.246.5023.0
  yarn add @design-systems/cli-utils@1.7.1-canary.246.5023.0
  yarn add @design-systems/cli@1.7.1-canary.246.5023.0
  yarn add @design-systems/core@1.7.1-canary.246.5023.0
  yarn add @design-systems/create@1.7.1-canary.246.5023.0
  yarn add @design-systems/eslint-config@1.7.1-canary.246.5023.0
  yarn add @design-systems/load-config@1.7.1-canary.246.5023.0
  yarn add @design-systems/plugin@1.7.1-canary.246.5023.0
  yarn add @design-systems/stylelint-config@1.7.1-canary.246.5023.0
  yarn add @design-systems/build@1.7.1-canary.246.5023.0
  yarn add @design-systems/bundle@1.7.1-canary.246.5023.0
  yarn add @design-systems/clean@1.7.1-canary.246.5023.0
  yarn add @design-systems/create-command@1.7.1-canary.246.5023.0
  yarn add @design-systems/dev@1.7.1-canary.246.5023.0
  yarn add @design-systems/lint@1.7.1-canary.246.5023.0
  yarn add @design-systems/playroom@1.7.1-canary.246.5023.0
  yarn add @design-systems/proof@1.7.1-canary.246.5023.0
  yarn add @design-systems/size@1.7.1-canary.246.5023.0
  yarn add @design-systems/storybook@1.7.1-canary.246.5023.0
  yarn add @design-systems/test@1.7.1-canary.246.5023.0
  yarn add @design-systems/update@1.7.1-canary.246.5023.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
