### PR TITLE
feat: enable custom playroom config

### DIFF
--- a/plugins/playroom/package.json
+++ b/plugins/playroom/package.json
@@ -26,6 +26,7 @@
     "@design-systems/plugin": "link:../../packages/plugin",
     "babel-plugin-import-redirect": "1.1.1",
     "css-loader": "3.4.2",
+    "dedent": "0.7.0",
     "fast-glob": "3.2.2",
     "file-loader": "5.0.2",
     "fork-ts-checker-webpack-plugin": "4.1.3",

--- a/plugins/playroom/src/command.ts
+++ b/plugins/playroom/src/command.ts
@@ -1,4 +1,5 @@
 import { CliCommand } from '@design-systems/plugin';
+import dedent from 'dedent';
 
 const command: CliCommand = {
   name: 'playroom',
@@ -38,6 +39,27 @@ const command: CliCommand = {
       header: 'Snippets',
       content:
         'Export an arrary of Playroom Snippets in each of your components. These will all be loaded into playroom at once.'
+    },
+    {
+      header: 'Custom playroom config',
+      content: dedent`
+        To customize your playroom configuration, create a playroom.config.js at your package or monorepo root. Export a function that takes the base config as an argument.
+
+        It must uses the passed in base config for playroom to function properly.
+      `
+    },
+    {
+      code: true,
+      content: dedent`
+        \`\`\`js
+        module.exports = baseConfig => ({
+          ...baseConfig,
+          port: 9001,
+          openBrowser: false,
+          title: 'Custom Title',
+        });
+        \`\`\`
+      `
     }
   ]
 };

--- a/plugins/playroom/src/playroom.config.ts
+++ b/plugins/playroom/src/playroom.config.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/ban-ts-ignore, @typescript-eslint/no-var-requires */
-
 import path from 'path';
 import fs from 'fs';
 // @ts-ignore
@@ -36,7 +35,6 @@ require('@babel/register')({
   extensions: ['.ts', '.tsx', '.jsx', '.js', '.mjs']
 });
 
-// TODO: remove this or change based on advice after PR
 interface PlayroomConfig {
   components: string;
   outputPath: string;
@@ -55,19 +53,20 @@ interface PlayroomConfig {
 /**
  * Modifies the playroom config by trying to load the user's custom config.
  */
-const loadUserPlayroomConfig = (config: PlayroomConfig): PlayroomConfig => {
+const loadUserPlayroomConfig = (baseConfig: PlayroomConfig): PlayroomConfig => {
   const userConfigPath = path.join(getMonorepoRoot(), 'playroom.config.js');
 
   if (fs.existsSync(userConfigPath)) {
     logger.debug(`Custom playroom config file: ${userConfigPath}`);
+    // eslint-disable-next-line global-require, import/no-dynamic-require
     const getUserConfig = require(userConfigPath);
-    const userConfig = getUserConfig({ config });
+    const userConfig = getUserConfig(baseConfig);
 
     logger.trace('Customized playroom config:', userConfig);
     return userConfig;
   }
 
-  return config;
+  return baseConfig;
 };
 
 export default async ({


### PR DESCRIPTION
# What Changed

Pass the default playroom config object to a function defined in _playroom.config.js_ at the root of the monorepo if it exists.

# Why

Add support for customizing playroom with local config file.

Here are examples of my local playroom config and frame component files that I'm testing with:
```js
// playroom.config.js
module.exports = ({ config }) => ({
  ...config,
  frameComponent: './playroom.frameComponent.js',
});

// playroom.frameComponent.js
import { ThemeProvider } from '@carecar-ds/theme';

export default ThemeProvider;
```

Todo:

~~- [ ] Add tests~~
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.5-canary.251.5572.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @design-systems/babel-plugin-include-styles@1.7.5-canary.251.5572.0
  npm install @design-systems/cli-utils@1.7.5-canary.251.5572.0
  npm install @design-systems/cli@1.7.5-canary.251.5572.0
  npm install @design-systems/core@1.7.5-canary.251.5572.0
  npm install @design-systems/create@1.7.5-canary.251.5572.0
  npm install @design-systems/eslint-config@1.7.5-canary.251.5572.0
  npm install @design-systems/load-config@1.7.5-canary.251.5572.0
  npm install @design-systems/plugin@1.7.5-canary.251.5572.0
  npm install @design-systems/stylelint-config@1.7.5-canary.251.5572.0
  npm install @design-systems/build@1.7.5-canary.251.5572.0
  npm install @design-systems/bundle@1.7.5-canary.251.5572.0
  npm install @design-systems/clean@1.7.5-canary.251.5572.0
  npm install @design-systems/create-command@1.7.5-canary.251.5572.0
  npm install @design-systems/dev@1.7.5-canary.251.5572.0
  npm install @design-systems/lint@1.7.5-canary.251.5572.0
  npm install @design-systems/playroom@1.7.5-canary.251.5572.0
  npm install @design-systems/proof@1.7.5-canary.251.5572.0
  npm install @design-systems/size@1.7.5-canary.251.5572.0
  npm install @design-systems/storybook@1.7.5-canary.251.5572.0
  npm install @design-systems/test@1.7.5-canary.251.5572.0
  npm install @design-systems/update@1.7.5-canary.251.5572.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@1.7.5-canary.251.5572.0
  yarn add @design-systems/cli-utils@1.7.5-canary.251.5572.0
  yarn add @design-systems/cli@1.7.5-canary.251.5572.0
  yarn add @design-systems/core@1.7.5-canary.251.5572.0
  yarn add @design-systems/create@1.7.5-canary.251.5572.0
  yarn add @design-systems/eslint-config@1.7.5-canary.251.5572.0
  yarn add @design-systems/load-config@1.7.5-canary.251.5572.0
  yarn add @design-systems/plugin@1.7.5-canary.251.5572.0
  yarn add @design-systems/stylelint-config@1.7.5-canary.251.5572.0
  yarn add @design-systems/build@1.7.5-canary.251.5572.0
  yarn add @design-systems/bundle@1.7.5-canary.251.5572.0
  yarn add @design-systems/clean@1.7.5-canary.251.5572.0
  yarn add @design-systems/create-command@1.7.5-canary.251.5572.0
  yarn add @design-systems/dev@1.7.5-canary.251.5572.0
  yarn add @design-systems/lint@1.7.5-canary.251.5572.0
  yarn add @design-systems/playroom@1.7.5-canary.251.5572.0
  yarn add @design-systems/proof@1.7.5-canary.251.5572.0
  yarn add @design-systems/size@1.7.5-canary.251.5572.0
  yarn add @design-systems/storybook@1.7.5-canary.251.5572.0
  yarn add @design-systems/test@1.7.5-canary.251.5572.0
  yarn add @design-systems/update@1.7.5-canary.251.5572.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
