### PR TITLE
copy .npmrc to temp.

### DIFF
--- a/plugins/size/src/command.ts
+++ b/plugins/size/src/command.ts
@@ -69,7 +69,7 @@ const command: CliCommand = {
     {
       name: 'registry',
       type: String,
-      description: 'The registry to install packages from',
+      description: 'The registry to install packages from. The plugin will use a local .npmrc file if available for authentication.',
       config: true
     },
     {

--- a/plugins/size/src/utils/WebpackUtils.ts
+++ b/plugins/size/src/utils/WebpackUtils.ts
@@ -173,6 +173,11 @@ async function getSizes(options: GetSizesOptions & CommonOptions) {
       fs.copyFileSync(browsersList, path.join(dir, '.browserslistrc'));
     }
 
+    const npmrc = path.join(getMonorepoRoot(), '.npmrc');
+    if (options.registry && fs.existsSync(npmrc)) {
+      fs.copyFileSync(npmrc, path.join(dir, '.npmrc'));
+    }
+
     logger.debug(`Installing: ${options.name}`);
     if (options.registry) {
       execSync(


### PR DESCRIPTION
# What Changed

The `registry` option on the `size` command will now copy the local .npmrc file to the temp directory if it exists.

# Why

This will allow for registries that require authentication.

I wasn't able to deprecate the `registry` option entirely because yarn seems to ignore the .npmrc when ran as a child process. This issue seems to corroborate that https://github.com/yarnpkg/yarn/issues/4298.  (bizarre).

So instead this functionality operates in tandem with explicitly setting the registry. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.8.2-canary.255.5690.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @design-systems/babel-plugin-include-styles@1.8.2-canary.255.5690.0
  npm install @design-systems/cli-utils@1.8.2-canary.255.5690.0
  npm install @design-systems/cli@1.8.2-canary.255.5690.0
  npm install @design-systems/core@1.8.2-canary.255.5690.0
  npm install @design-systems/create@1.8.2-canary.255.5690.0
  npm install @design-systems/eslint-config@1.8.2-canary.255.5690.0
  npm install @design-systems/load-config@1.8.2-canary.255.5690.0
  npm install @design-systems/plugin@1.8.2-canary.255.5690.0
  npm install @design-systems/stylelint-config@1.8.2-canary.255.5690.0
  npm install @design-systems/build@1.8.2-canary.255.5690.0
  npm install @design-systems/bundle@1.8.2-canary.255.5690.0
  npm install @design-systems/clean@1.8.2-canary.255.5690.0
  npm install @design-systems/create-command@1.8.2-canary.255.5690.0
  npm install @design-systems/dev@1.8.2-canary.255.5690.0
  npm install @design-systems/lint@1.8.2-canary.255.5690.0
  npm install @design-systems/playroom@1.8.2-canary.255.5690.0
  npm install @design-systems/proof@1.8.2-canary.255.5690.0
  npm install @design-systems/size@1.8.2-canary.255.5690.0
  npm install @design-systems/storybook@1.8.2-canary.255.5690.0
  npm install @design-systems/test@1.8.2-canary.255.5690.0
  npm install @design-systems/update@1.8.2-canary.255.5690.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@1.8.2-canary.255.5690.0
  yarn add @design-systems/cli-utils@1.8.2-canary.255.5690.0
  yarn add @design-systems/cli@1.8.2-canary.255.5690.0
  yarn add @design-systems/core@1.8.2-canary.255.5690.0
  yarn add @design-systems/create@1.8.2-canary.255.5690.0
  yarn add @design-systems/eslint-config@1.8.2-canary.255.5690.0
  yarn add @design-systems/load-config@1.8.2-canary.255.5690.0
  yarn add @design-systems/plugin@1.8.2-canary.255.5690.0
  yarn add @design-systems/stylelint-config@1.8.2-canary.255.5690.0
  yarn add @design-systems/build@1.8.2-canary.255.5690.0
  yarn add @design-systems/bundle@1.8.2-canary.255.5690.0
  yarn add @design-systems/clean@1.8.2-canary.255.5690.0
  yarn add @design-systems/create-command@1.8.2-canary.255.5690.0
  yarn add @design-systems/dev@1.8.2-canary.255.5690.0
  yarn add @design-systems/lint@1.8.2-canary.255.5690.0
  yarn add @design-systems/playroom@1.8.2-canary.255.5690.0
  yarn add @design-systems/proof@1.8.2-canary.255.5690.0
  yarn add @design-systems/size@1.8.2-canary.255.5690.0
  yarn add @design-systems/storybook@1.8.2-canary.255.5690.0
  yarn add @design-systems/test@1.8.2-canary.255.5690.0
  yarn add @design-systems/update@1.8.2-canary.255.5690.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
