### PR TITLE
feat: adding ability to send failure threshold from args

### DIFF
--- a/plugins/size/src/command.ts
+++ b/plugins/size/src/command.ts
@@ -78,7 +78,12 @@ const command: CliCommand = {
       description:
         'Comment on the Pull request with the results. (Only from CI + must set env var GH_TOKEN. In jenkins OWNER and REPO must also be set. In enterprise you must also set GITHUB_URL)',
       config: true
-    }
+    },
+    {
+      name: 'failureThreshold',
+      type: String,
+      description: 'Failure Threshold for Size'
+    },    
   ]
 };
 

--- a/plugins/size/src/command.ts
+++ b/plugins/size/src/command.ts
@@ -81,7 +81,7 @@ const command: CliCommand = {
     },
     {
       name: 'failureThreshold',
-      type: String,
+      type: Number,
       description: 'Failure Threshold for Size'
     },    
   ]

--- a/plugins/size/src/command.ts
+++ b/plugins/size/src/command.ts
@@ -82,8 +82,9 @@ const command: CliCommand = {
     {
       name: 'failureThreshold',
       type: Number,
-      description: 'Failure Threshold for Size'
-    },    
+      description: 'Failure Threshold for Size',
+      config: true
+    }    
   ]
 };
 

--- a/plugins/size/src/index.ts
+++ b/plugins/size/src/index.ts
@@ -30,7 +30,7 @@ const defaultHeader = ['master', 'pr', '+/-', '%'];
 export default class SizePlugin implements Plugin<SizeArgs> {
   async run(args: SizeArgs) {
 
-    let FAILURE_THRESHOLD = args.failureThreshold || 5;
+    const FAILURE_THRESHOLD = args.failureThreshold || 5;
     logger.info(`FAILURE_THRESHOLD : ${FAILURE_THRESHOLD}`);
 
     if (args.ci) {

--- a/plugins/size/src/index.ts
+++ b/plugins/size/src/index.ts
@@ -31,7 +31,7 @@ export default class SizePlugin implements Plugin<SizeArgs> {
   async run(args: SizeArgs) {
 
     let FAILURE_THRESHOLD = args.failureThreshold || 5;
-    logger.debug(`FAILURE_THRESHOLD : ${FAILURE_THRESHOLD}`);
+    logger.info(`FAILURE_THRESHOLD : ${FAILURE_THRESHOLD}`);
 
     if (args.ci) {
       logger.disable();

--- a/plugins/size/src/index.ts
+++ b/plugins/size/src/index.ts
@@ -12,7 +12,6 @@ import { startAnalyze } from "./utils/WebpackUtils";
 import { createDiff } from "./utils/DiffUtils";
 
 const logger = createLogger({ scope: 'size' });
-const FAILURE_THRESHOLD = 5;
 
 const cssHeader = [
   'master: js',
@@ -30,6 +29,10 @@ const defaultHeader = ['master', 'pr', '+/-', '%'];
 /** A plugin to determine the size changes of packages. */
 export default class SizePlugin implements Plugin<SizeArgs> {
   async run(args: SizeArgs) {
+
+    let FAILURE_THRESHOLD = args.failureThreshold || 5;
+    logger.debug(`FAILURE_THRESHOLD : ${FAILURE_THRESHOLD}`);
+
     if (args.ci) {
       logger.disable();
     }

--- a/plugins/size/src/interfaces.ts
+++ b/plugins/size/src/interfaces.ts
@@ -19,6 +19,8 @@ export interface SizeArgs {
   ignore?: string[]
   /** The registry to install packages from */
   registry?: string
+  /** Size Failure Threshold */
+  failureThreshold?: number
 }
 
 export interface Export {

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,7 +118,7 @@
   optionalDependencies:
     chokidar "^2.1.8"
 
-"@babel/code-frame@7.10.1", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.1":
+"@babel/code-frame@7.10.1", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.1", "@babel/code-frame@^7.5.5":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.1.tgz#d5481c5095daa1c57e16e54c6f9198443afb49ff"
   integrity sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==


### PR DESCRIPTION
# What Changed
Adding an option to override the Failure Threshold value from args

# Why

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.1-canary.275.6818.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @design-systems/babel-plugin-include-styles@1.9.1-canary.275.6818.0
  npm install @design-systems/cli-utils@1.9.1-canary.275.6818.0
  npm install @design-systems/cli@1.9.1-canary.275.6818.0
  npm install @design-systems/core@1.9.1-canary.275.6818.0
  npm install @design-systems/create@1.9.1-canary.275.6818.0
  npm install @design-systems/eslint-config@1.9.1-canary.275.6818.0
  npm install @design-systems/load-config@1.9.1-canary.275.6818.0
  npm install @design-systems/plugin@1.9.1-canary.275.6818.0
  npm install @design-systems/stylelint-config@1.9.1-canary.275.6818.0
  npm install @design-systems/build@1.9.1-canary.275.6818.0
  npm install @design-systems/bundle@1.9.1-canary.275.6818.0
  npm install @design-systems/clean@1.9.1-canary.275.6818.0
  npm install @design-systems/create-command@1.9.1-canary.275.6818.0
  npm install @design-systems/dev@1.9.1-canary.275.6818.0
  npm install @design-systems/lint@1.9.1-canary.275.6818.0
  npm install @design-systems/playroom@1.9.1-canary.275.6818.0
  npm install @design-systems/proof@1.9.1-canary.275.6818.0
  npm install @design-systems/size@1.9.1-canary.275.6818.0
  npm install @design-systems/storybook@1.9.1-canary.275.6818.0
  npm install @design-systems/test@1.9.1-canary.275.6818.0
  npm install @design-systems/update@1.9.1-canary.275.6818.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@1.9.1-canary.275.6818.0
  yarn add @design-systems/cli-utils@1.9.1-canary.275.6818.0
  yarn add @design-systems/cli@1.9.1-canary.275.6818.0
  yarn add @design-systems/core@1.9.1-canary.275.6818.0
  yarn add @design-systems/create@1.9.1-canary.275.6818.0
  yarn add @design-systems/eslint-config@1.9.1-canary.275.6818.0
  yarn add @design-systems/load-config@1.9.1-canary.275.6818.0
  yarn add @design-systems/plugin@1.9.1-canary.275.6818.0
  yarn add @design-systems/stylelint-config@1.9.1-canary.275.6818.0
  yarn add @design-systems/build@1.9.1-canary.275.6818.0
  yarn add @design-systems/bundle@1.9.1-canary.275.6818.0
  yarn add @design-systems/clean@1.9.1-canary.275.6818.0
  yarn add @design-systems/create-command@1.9.1-canary.275.6818.0
  yarn add @design-systems/dev@1.9.1-canary.275.6818.0
  yarn add @design-systems/lint@1.9.1-canary.275.6818.0
  yarn add @design-systems/playroom@1.9.1-canary.275.6818.0
  yarn add @design-systems/proof@1.9.1-canary.275.6818.0
  yarn add @design-systems/size@1.9.1-canary.275.6818.0
  yarn add @design-systems/storybook@1.9.1-canary.275.6818.0
  yarn add @design-systems/test@1.9.1-canary.275.6818.0
  yarn add @design-systems/update@1.9.1-canary.275.6818.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
