### PR TITLE
Adds support for --max-warnings flag in lint command

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -32,7 +32,7 @@ export type MultiCommand = Overwrite<
 export type CliCommand = Command | MultiCommand;
 
 /** A plugin to the @design-systems/cli */
-export interface Plugin<T = any> {
+export interface Plugin<T = unknown> {
   /** Ran when the user inputs the registered command */
   run(args: T): Promise<void>;
 }

--- a/plugins/lint/src/command.ts
+++ b/plugins/lint/src/command.ts
@@ -29,6 +29,13 @@ const command: CliCommand = {
         'A list of files to lint. Omit to automatically scan the repo.',
       multiple: true,
       defaultOption: true
+    },
+    {
+      name: 'max-warnings',
+      type: Number,
+      description: 'An optional maximum number of warnings to show.',
+      multiple: false,
+      defaultValue: 0
     }
   ]
 };

--- a/plugins/lint/src/command.ts
+++ b/plugins/lint/src/command.ts
@@ -33,9 +33,9 @@ const command: CliCommand = {
     {
       name: 'max-warnings',
       type: Number,
-      description: 'An optional maximum number of warnings to show.',
+      description: 'Number of warnings to trigger nonzero exit code.',
       multiple: false,
-      defaultValue: 0
+      defaultValue: 1
     }
   ]
 };

--- a/plugins/lint/src/index.ts
+++ b/plugins/lint/src/index.ts
@@ -23,12 +23,12 @@ export default class LintPlugin implements Plugin<LintArgs> {
     }
 
     try {
-      const jsErrors = await lintJS(args);
-      const cssErrors = await lintCSS(args);
+      const jsReturnCode = await lintJS(args);
+      const cssReturnCode = await lintCSS(args);
 
-      logger.debug({ jsErrors, cssErrors });
+      logger.debug({ jsReturnCode, cssReturnCode });
 
-      if (jsErrors + cssErrors > 0) {
+      if (jsReturnCode + cssReturnCode > 0) {
         process.exit(1);
       }
     } catch (e) {

--- a/plugins/lint/src/interfaces.ts
+++ b/plugins/lint/src/interfaces.ts
@@ -9,6 +9,8 @@ export interface LintArgs {
     annotate?: boolean;
     /** An optional list of files to lint */
     files?: string[];
+    /** An optional maximum number of warnings to show */
+    maxWarnings?: number;
 }
 
 export type StylelintResult = stylelint.LinterResult & {

--- a/plugins/lint/src/interfaces.ts
+++ b/plugins/lint/src/interfaces.ts
@@ -9,7 +9,7 @@ export interface LintArgs {
     annotate?: boolean;
     /** An optional list of files to lint */
     files?: string[];
-    /** An optional maximum number of warnings to show */
+    /** An optional number of warnings to trigger nonzero exit code, default: 1 */
     maxWarnings?: number;
 }
 

--- a/plugins/lint/src/utils/lintUtils.ts
+++ b/plugins/lint/src/utils/lintUtils.ts
@@ -75,7 +75,7 @@ async function lintJS(args: LintArgs): Promise<number> {
     args.files ? files(args, 'ts|tsx|js|jsx|mdx') : lintFiles
   );
 
-  const maxWarnings = args.maxWarnings ? args.maxWarnings : 0;
+  const maxWarnings = args.maxWarnings ? args.maxWarnings : 1;
 
   if (args.fix) {
     CLIEngine.outputFixes(report);
@@ -88,7 +88,7 @@ async function lintJS(args: LintArgs): Promise<number> {
 
   if (report.errorCount > 0) {
     logger.error('Project contains JS errors', formattedResults);
-  } else if (report.warningCount > maxWarnings) {
+  } else if (report.warningCount >= maxWarnings) {
     logger.warn('Project contains JS warnings (maximum allowable: %s)', maxWarnings, formattedResults);
   } else {
     logger.success('JS');
@@ -98,7 +98,7 @@ async function lintJS(args: LintArgs): Promise<number> {
     await createESLintAnnotations(report.results);
   }
 
-  const returnCode = (report.errorCount > 0 || report.warningCount > maxWarnings) ? 1 : 0;
+  const returnCode = (report.errorCount > 0 || report.warningCount >= maxWarnings) ? 1 : 0;
   return returnCode;
 }
 

--- a/plugins/lint/src/utils/lintUtils.ts
+++ b/plugins/lint/src/utils/lintUtils.ts
@@ -89,7 +89,7 @@ async function lintJS(args: LintArgs): Promise<number> {
   if (report.errorCount > 0) {
     logger.error('Project contains JS errors', formattedResults);
   } else if (report.warningCount >= maxWarnings) {
-    logger.warn('Project contains JS warnings (maximum allowable: %s)', maxWarnings, formattedResults);
+    logger.warn('Project contains JS warnings (maximum allowable: %s)', maxWarnings-1, formattedResults);
   } else {
     logger.success('JS');
   }
@@ -98,8 +98,7 @@ async function lintJS(args: LintArgs): Promise<number> {
     await createESLintAnnotations(report.results);
   }
 
-  const returnCode = (report.errorCount > 0 || report.warningCount >= maxWarnings) ? 1 : 0;
-  return returnCode;
+  return (report.errorCount > 0 || report.warningCount >= maxWarnings) ? 1 : 0;
 }
 
 /** Link CSS */

--- a/plugins/size/src/utils/CalcSizeUtils.ts
+++ b/plugins/size/src/utils/CalcSizeUtils.ts
@@ -175,16 +175,16 @@ function getChangedPackages() {
 
     return packages
       .map((p: string) => JSON.parse(p))
-      .filter((json: Record<string, any>) =>
+      .filter((json: Record<string, unknown>) =>
         changedFiles.some((file) => {
-          const hasChangedFiles = file.includes(json.location);
+          const hasChangedFiles = file.includes(String(json.location));
 
           if (hasChangedFiles) {
-            changedDeps.push(json.name);
+            changedDeps.push(String(json.name));
           } else {
             // Check if a dep has changed too
             const packageJson = JSON.parse(
-              fs.readFileSync(path.join(json.location, 'package.json'), {
+              fs.readFileSync(path.join(String(json.location), 'package.json'), {
                 encoding: 'utf-8',
               })
             );
@@ -193,7 +193,7 @@ function getChangedPackages() {
             );
 
             if (hasChangedDep) {
-              changedDeps.push(json.name);
+              changedDeps.push(String(json.name));
               return hasChangedDep;
             }
           }
@@ -201,7 +201,7 @@ function getChangedPackages() {
           return hasChangedFiles;
         })
       )
-      .map((json: Record<string, any>) => {
+      .map((json) => {
         return { location: json.location, package: { ...json } };
       });
   } catch (error) {


### PR DESCRIPTION
# What Changed

Support for `--max-warnings` flag for the `lint` command has been added, as per feature request #200.

# Why

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.5-canary.485.9497.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.0.5-canary.485.9497.0
  npm install @design-systems/cli-utils@2.0.5-canary.485.9497.0
  npm install @design-systems/cli@2.0.5-canary.485.9497.0
  npm install @design-systems/core@2.0.5-canary.485.9497.0
  npm install @design-systems/create@2.0.5-canary.485.9497.0
  npm install @design-systems/docs@2.0.5-canary.485.9497.0
  npm install @design-systems/eslint-config@2.0.5-canary.485.9497.0
  npm install @design-systems/load-config@2.0.5-canary.485.9497.0
  npm install @design-systems/plugin@2.0.5-canary.485.9497.0
  npm install @design-systems/stylelint-config@2.0.5-canary.485.9497.0
  npm install @design-systems/build@2.0.5-canary.485.9497.0
  npm install @design-systems/bundle@2.0.5-canary.485.9497.0
  npm install @design-systems/clean@2.0.5-canary.485.9497.0
  npm install @design-systems/create-command@2.0.5-canary.485.9497.0
  npm install @design-systems/dev@2.0.5-canary.485.9497.0
  npm install @design-systems/lint@2.0.5-canary.485.9497.0
  npm install @design-systems/playroom@2.0.5-canary.485.9497.0
  npm install @design-systems/proof@2.0.5-canary.485.9497.0
  npm install @design-systems/size@2.0.5-canary.485.9497.0
  npm install @design-systems/storybook@2.0.5-canary.485.9497.0
  npm install @design-systems/test@2.0.5-canary.485.9497.0
  npm install @design-systems/update@2.0.5-canary.485.9497.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.0.5-canary.485.9497.0
  yarn add @design-systems/cli-utils@2.0.5-canary.485.9497.0
  yarn add @design-systems/cli@2.0.5-canary.485.9497.0
  yarn add @design-systems/core@2.0.5-canary.485.9497.0
  yarn add @design-systems/create@2.0.5-canary.485.9497.0
  yarn add @design-systems/docs@2.0.5-canary.485.9497.0
  yarn add @design-systems/eslint-config@2.0.5-canary.485.9497.0
  yarn add @design-systems/load-config@2.0.5-canary.485.9497.0
  yarn add @design-systems/plugin@2.0.5-canary.485.9497.0
  yarn add @design-systems/stylelint-config@2.0.5-canary.485.9497.0
  yarn add @design-systems/build@2.0.5-canary.485.9497.0
  yarn add @design-systems/bundle@2.0.5-canary.485.9497.0
  yarn add @design-systems/clean@2.0.5-canary.485.9497.0
  yarn add @design-systems/create-command@2.0.5-canary.485.9497.0
  yarn add @design-systems/dev@2.0.5-canary.485.9497.0
  yarn add @design-systems/lint@2.0.5-canary.485.9497.0
  yarn add @design-systems/playroom@2.0.5-canary.485.9497.0
  yarn add @design-systems/proof@2.0.5-canary.485.9497.0
  yarn add @design-systems/size@2.0.5-canary.485.9497.0
  yarn add @design-systems/storybook@2.0.5-canary.485.9497.0
  yarn add @design-systems/test@2.0.5-canary.485.9497.0
  yarn add @design-systems/update@2.0.5-canary.485.9497.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
