### PR TITLE
Only generate .js file mappings for the main css output

### DIFF
--- a/plugins/build/src/index.ts
+++ b/plugins/build/src/index.ts
@@ -254,6 +254,7 @@ export default class BuildPlugin implements Plugin<BuildArgs> {
               inDir: inputDirectory,
               outDir: outputDirectory,
               configFile: POSTCSS_CONFIG,
+              isCssMain: true,
               watch: this.buildArgs.watch,
             })
               // Save the CSS output for merging later
@@ -281,6 +282,7 @@ export default class BuildPlugin implements Plugin<BuildArgs> {
             outDir: outputDirectory,
             configFile: POSTCSS_CONFIG,
             multiBuildConfigFile: config.path,
+            isCssMain: this.buildArgs.cssMain === config.name,
             watch: this.buildArgs.watch,
           });
 

--- a/plugins/build/src/postcss.ts
+++ b/plugins/build/src/postcss.ts
@@ -162,6 +162,8 @@ interface TranspileOptions {
   configFile: string;
   /** A multibuild config file to use if not overridden */
   multiBuildConfigFile?: string;
+  /** If this css file represents everything */
+  isCssMain: boolean;
   /** The builder was started in watch mode */
   watch: boolean;
 }
@@ -176,6 +178,7 @@ interface TranspileOptions {
 export default async function transpile({
   inFile,
   inDir,
+  isCssMain,
   outDir,
   configFile,
   multiBuildConfigFile,
@@ -197,17 +200,19 @@ export default async function transpile({
     const result = await processor.process(fileContents, {
       ...options,
       plugins,
-      to: cssFile,
+      to: isCssMain ? cssFile : undefined,
       from: inFile,
       map: { inline: false },
     });
 
-    await fs.outputFile(
-      `${cssFile}.map`,
-      result.map
-        .toString()
-        .replace(/<input css (\d+)>/g, '../src/<input css $1>')
-    );
+    if (isCssMain) {
+      await fs.outputFile(
+        `${cssFile}.map`,
+        result.map
+          .toString()
+          .replace(/<input css (\d+)>/g, '../src/<input css $1>')
+      );
+    }
 
     return result;
   } catch (error) {


### PR DESCRIPTION
# What Changed

The multi-build postcss configs were overriding the `.css.js` mapping files. This means the last build in the pipeline would always be the one to output it's classname map. 

If it happens to be a config that omits themes, none of the theme classes will appear in the output (and won't be used by components)

This only outputs the `.css.js` mapping when the config is the `cssMain` file (which _should_ contain all theme info for proper classname maps)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.3.1-canary.514.10061.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.3.1-canary.514.10061.0
  npm install @design-systems/babel-plugin-replace-styles@2.3.1-canary.514.10061.0
  npm install @design-systems/cli-utils@2.3.1-canary.514.10061.0
  npm install @design-systems/cli@2.3.1-canary.514.10061.0
  npm install @design-systems/core@2.3.1-canary.514.10061.0
  npm install @design-systems/create@2.3.1-canary.514.10061.0
  npm install @design-systems/docs@2.3.1-canary.514.10061.0
  npm install @design-systems/eslint-config@2.3.1-canary.514.10061.0
  npm install @design-systems/load-config@2.3.1-canary.514.10061.0
  npm install @design-systems/plugin@2.3.1-canary.514.10061.0
  npm install @design-systems/stylelint-config@2.3.1-canary.514.10061.0
  npm install @design-systems/build@2.3.1-canary.514.10061.0
  npm install @design-systems/bundle@2.3.1-canary.514.10061.0
  npm install @design-systems/clean@2.3.1-canary.514.10061.0
  npm install @design-systems/create-command@2.3.1-canary.514.10061.0
  npm install @design-systems/dev@2.3.1-canary.514.10061.0
  npm install @design-systems/lint@2.3.1-canary.514.10061.0
  npm install @design-systems/playroom@2.3.1-canary.514.10061.0
  npm install @design-systems/proof@2.3.1-canary.514.10061.0
  npm install @design-systems/size@2.3.1-canary.514.10061.0
  npm install @design-systems/storybook@2.3.1-canary.514.10061.0
  npm install @design-systems/test@2.3.1-canary.514.10061.0
  npm install @design-systems/update@2.3.1-canary.514.10061.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.3.1-canary.514.10061.0
  yarn add @design-systems/babel-plugin-replace-styles@2.3.1-canary.514.10061.0
  yarn add @design-systems/cli-utils@2.3.1-canary.514.10061.0
  yarn add @design-systems/cli@2.3.1-canary.514.10061.0
  yarn add @design-systems/core@2.3.1-canary.514.10061.0
  yarn add @design-systems/create@2.3.1-canary.514.10061.0
  yarn add @design-systems/docs@2.3.1-canary.514.10061.0
  yarn add @design-systems/eslint-config@2.3.1-canary.514.10061.0
  yarn add @design-systems/load-config@2.3.1-canary.514.10061.0
  yarn add @design-systems/plugin@2.3.1-canary.514.10061.0
  yarn add @design-systems/stylelint-config@2.3.1-canary.514.10061.0
  yarn add @design-systems/build@2.3.1-canary.514.10061.0
  yarn add @design-systems/bundle@2.3.1-canary.514.10061.0
  yarn add @design-systems/clean@2.3.1-canary.514.10061.0
  yarn add @design-systems/create-command@2.3.1-canary.514.10061.0
  yarn add @design-systems/dev@2.3.1-canary.514.10061.0
  yarn add @design-systems/lint@2.3.1-canary.514.10061.0
  yarn add @design-systems/playroom@2.3.1-canary.514.10061.0
  yarn add @design-systems/proof@2.3.1-canary.514.10061.0
  yarn add @design-systems/size@2.3.1-canary.514.10061.0
  yarn add @design-systems/storybook@2.3.1-canary.514.10061.0
  yarn add @design-systems/test@2.3.1-canary.514.10061.0
  yarn add @design-systems/update@2.3.1-canary.514.10061.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
