### PR TITLE
add Next.js plugin to allow CSS imports for components build with 'ds build'

### DIFF
--- a/packages/next-esm-css/README.md
+++ b/packages/next-esm-css/README.md
@@ -27,3 +27,8 @@ module.exports = withEsmCss();
 ```
 
 Now Next.js won't break when you import a component build with `ds`!
+
+## Inspration
+
+This package heavily borrows from [next-transpiled-modules](https://www.npmjs.com/package/next-transpile-modules).
+You could use that package instead, but this package is a bit faster when building since it only affects CSS.

--- a/packages/next-esm-css/README.md
+++ b/packages/next-esm-css/README.md
@@ -1,0 +1,29 @@
+# @design-systems/next-esm-css
+
+This package enables using the `esm` output from the `ds build` command in a Next.js based project.
+Currently Next.js doesn't allow `node_modules` to import their own CSS so using components from a `ds` based project doesn't work.
+[See this issue](https://github.com/vercel/next.js/issues/13282).
+
+## Installation
+
+```sh
+npm i @design-systems/next-esm-css
+# or with yarn
+yarn add @design-systems/next-esm-css
+```
+
+## Usage
+
+Simply require this package in your `next.config.js` and provide either a list of package names or a regex for everything in your design system scope.
+
+**`next.config.js`:**
+
+```js
+const withEsmCss = require('@design-systems/next-esm-css')([
+  '@your-design-system-scope/.*',
+]);
+
+module.exports = withEsmCss();
+```
+
+Now Next.js won't break when you import a component build with `ds`!

--- a/packages/next-esm-css/jest.config.js
+++ b/packages/next-esm-css/jest.config.js
@@ -1,0 +1,8 @@
+const base = require('@design-systems/test/jest.config.base');
+const { name } = require('./package.json');
+
+module.exports = {
+  ...base,
+  name,
+  displayName: name
+};

--- a/packages/next-esm-css/package.json
+++ b/packages/next-esm-css/package.json
@@ -1,23 +1,16 @@
 {
   "name": "@design-systems/next-esm-css",
   "version": "2.5.4",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist",
+  "main": "./src/index.js",
   "repository": "https://github.com/intuit/design-systems-cli.git",
   "author": "Andrew Lisowski lisowski54@gmail.com",
   "contributors": ["Andrew Lisowski lisowski54@gmail.com"],
   "license": "MIT",
-  "scripts": {
-    "clean": "ds clean",
-    "build": "ds build",
-    "start": "ds build --watch",
-    "test": "ds test",
-    "lint": "ds lint",
-    "size": "ds size"
-  },
   "files": ["dist", "src", "!*.test.*", "!__snapshots__", "!__tests__"],
   "dependencies": {
     "@babel/runtime": "~7.11.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/next-esm-css/package.json
+++ b/packages/next-esm-css/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@design-systems/next-esm-css",
+  "version": "2.5.4",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist",
+  "repository": "https://github.com/intuit/design-systems-cli.git",
+  "author": "Andrew Lisowski lisowski54@gmail.com",
+  "contributors": ["Andrew Lisowski lisowski54@gmail.com"],
+  "license": "MIT",
+  "scripts": {
+    "clean": "ds clean",
+    "build": "ds build",
+    "start": "ds build --watch",
+    "test": "ds test",
+    "lint": "ds lint",
+    "size": "ds size"
+  },
+  "files": ["dist", "src", "!*.test.*", "!__snapshots__", "!__tests__"],
+  "dependencies": {
+    "@babel/runtime": "~7.11.2"
+  }
+}

--- a/packages/next-esm-css/src/index.js
+++ b/packages/next-esm-css/src/index.js
@@ -1,0 +1,128 @@
+/* eslint-disable */
+
+const path = require('path');
+
+const PATH_DELIMITER = '[\\\\/]'; // match 2 antislashes or one slash
+
+// Use me when needed
+// const inspect = (object) => {
+//   console.log(util.inspect(object, { showHidden: false, depth: null }));
+// };
+
+/**
+ * Stolen from https://stackoverflow.com/questions/10776600/testing-for-equality-of-regular-expressions
+ */
+const regexEqual = (x, y) => {
+  return (
+    x instanceof RegExp &&
+    y instanceof RegExp &&
+    x.source === y.source &&
+    x.global === y.global &&
+    x.ignoreCase === y.ignoreCase &&
+    x.multiline === y.multiline
+  );
+};
+
+const generateIncludes = (modules) => {
+  return [
+    new RegExp(`(${modules.map(safePath).join('|')})$`),
+    new RegExp(
+      `(${modules.map(safePath).join('|')})${PATH_DELIMITER}(?!.*node_modules)`
+    ),
+  ];
+};
+
+const generateExcludes = (modules) => {
+  return [
+    new RegExp(
+      `node_modules${PATH_DELIMITER}(?!(${modules
+        .map(safePath)
+        .join('|')})(${PATH_DELIMITER}|$)(?!.*node_modules))`
+    ),
+  ];
+};
+
+/**
+ * On Windows, the Regex won't match as Webpack tries to resolve the
+ * paths of the modules. So we need to check for \\ and /
+ */
+const safePath = (module) => module.split(/[\\\/]/g).join(PATH_DELIMITER);
+
+/**
+ * Actual Next.js plugin
+ */
+const withTmInitializer = (modules = []) => {
+  const withTM = (nextConfig = {}) => {
+    const includes = generateIncludes(modules);
+    const excludes = generateExcludes(modules);
+
+    return Object.assign({}, nextConfig, {
+      webpack(config, options) {
+        // Support CSS modules + global in node_modules
+        // TODO ask Next.js maintainer to expose the css-loader via defaultLoaders
+        const nextCssLoaders = config.module.rules.find(
+          (rule) => typeof rule.oneOf === 'object'
+        );
+
+        // .module.css
+        if (nextCssLoaders) {
+          const nextCssLoader = nextCssLoaders.oneOf.find((rule) =>
+            regexEqual(rule.test, /(?<!\.module)\.css$/)
+          );
+
+          if (nextCssLoader) {
+            nextCssLoader.issuer.or = nextCssLoader.issuer.and
+              ? nextCssLoader.issuer.and.concat(includes)
+              : includes;
+            nextCssLoader.issuer.not = excludes;
+            delete nextCssLoader.issuer.and;
+          }
+
+          // Hack our way to disable errors on node_modules CSS modules
+          const nextErrorCssModuleLoader = nextCssLoaders.oneOf.find(
+            (rule) =>
+              rule.use &&
+              rule.use.loader === 'error-loader' &&
+              rule.use.options &&
+              (rule.use.options.reason ===
+                'CSS Modules \u001b[1mcannot\u001b[22m be imported from within \u001b[1mnode_modules\u001b[22m.\n' +
+                  'Read more: https://err.sh/next.js/css-modules-npm' ||
+                rule.use.options.reason ===
+                  'CSS Modules cannot be imported from within node_modules.\nRead more: https://err.sh/next.js/css-modules-npm')
+          );
+
+          if (nextErrorCssModuleLoader) {
+            nextErrorCssModuleLoader.exclude = includes;
+          }
+
+          const nextErrorCssGlobalLoader = nextCssLoaders.oneOf.find(
+            (rule) =>
+              rule.use &&
+              rule.use.loader === 'error-loader' &&
+              rule.use.options &&
+              (rule.use.options.reason ===
+                'Global CSS \u001b[1mcannot\u001b[22m be imported from within \u001b[1mnode_modules\u001b[22m.\n' +
+                  'Read more: https://err.sh/next.js/css-npm' ||
+                rule.use.options.reason ===
+                  'Global CSS cannot be imported from within node_modules.\nRead more: https://err.sh/next.js/css-npm')
+          );
+
+          if (nextErrorCssGlobalLoader) {
+            nextErrorCssGlobalLoader.exclude = includes;
+          }
+        }
+
+        // Overload the Webpack config if it was already overloaded
+        if (typeof nextConfig.webpack === 'function') {
+          return nextConfig.webpack(config, options);
+        }
+
+        return config;
+      },
+    });
+  };
+
+  return withTM;
+};
+
+module.exports = withTmInitializer;

--- a/packages/next-esm-css/tsconfig.json
+++ b/packages/next-esm-css/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*", "../../typings/**/*"],
+
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  }
+}

--- a/scripts/template-plugin/package.json
+++ b/scripts/template-plugin/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "https://github.com/intuit/design-systems-cli.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@design-systems/cli-utils": "link:../../packages/cli-utils",
     "@design-systems/plugin": "link:../../packages/plugin"


### PR DESCRIPTION
# What Changed

see title

# Why

Our new way of building css doesn't work with Next.js

Todo:

- [ ] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.5.5-canary.552.10716.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.5.5-canary.552.10716.0
  npm install @design-systems/babel-plugin-replace-styles@2.5.5-canary.552.10716.0
  npm install @design-systems/cli-utils@2.5.5-canary.552.10716.0
  npm install @design-systems/cli@2.5.5-canary.552.10716.0
  npm install @design-systems/core@2.5.5-canary.552.10716.0
  npm install @design-systems/create@2.5.5-canary.552.10716.0
  npm install @design-systems/docs@2.5.5-canary.552.10716.0
  npm install @design-systems/eslint-config@2.5.5-canary.552.10716.0
  npm install @design-systems/load-config@2.5.5-canary.552.10716.0
  npm install @design-systems/next-esm-css@2.5.5-canary.552.10716.0
  npm install @design-systems/plugin@2.5.5-canary.552.10716.0
  npm install @design-systems/stylelint-config@2.5.5-canary.552.10716.0
  npm install @design-systems/utils@2.5.5-canary.552.10716.0
  npm install @design-systems/build@2.5.5-canary.552.10716.0
  npm install @design-systems/bundle@2.5.5-canary.552.10716.0
  npm install @design-systems/clean@2.5.5-canary.552.10716.0
  npm install @design-systems/create-command@2.5.5-canary.552.10716.0
  npm install @design-systems/dev@2.5.5-canary.552.10716.0
  npm install @design-systems/lint@2.5.5-canary.552.10716.0
  npm install @design-systems/playroom@2.5.5-canary.552.10716.0
  npm install @design-systems/proof@2.5.5-canary.552.10716.0
  npm install @design-systems/size@2.5.5-canary.552.10716.0
  npm install @design-systems/storybook@2.5.5-canary.552.10716.0
  npm install @design-systems/test@2.5.5-canary.552.10716.0
  npm install @design-systems/update@2.5.5-canary.552.10716.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.5.5-canary.552.10716.0
  yarn add @design-systems/babel-plugin-replace-styles@2.5.5-canary.552.10716.0
  yarn add @design-systems/cli-utils@2.5.5-canary.552.10716.0
  yarn add @design-systems/cli@2.5.5-canary.552.10716.0
  yarn add @design-systems/core@2.5.5-canary.552.10716.0
  yarn add @design-systems/create@2.5.5-canary.552.10716.0
  yarn add @design-systems/docs@2.5.5-canary.552.10716.0
  yarn add @design-systems/eslint-config@2.5.5-canary.552.10716.0
  yarn add @design-systems/load-config@2.5.5-canary.552.10716.0
  yarn add @design-systems/next-esm-css@2.5.5-canary.552.10716.0
  yarn add @design-systems/plugin@2.5.5-canary.552.10716.0
  yarn add @design-systems/stylelint-config@2.5.5-canary.552.10716.0
  yarn add @design-systems/utils@2.5.5-canary.552.10716.0
  yarn add @design-systems/build@2.5.5-canary.552.10716.0
  yarn add @design-systems/bundle@2.5.5-canary.552.10716.0
  yarn add @design-systems/clean@2.5.5-canary.552.10716.0
  yarn add @design-systems/create-command@2.5.5-canary.552.10716.0
  yarn add @design-systems/dev@2.5.5-canary.552.10716.0
  yarn add @design-systems/lint@2.5.5-canary.552.10716.0
  yarn add @design-systems/playroom@2.5.5-canary.552.10716.0
  yarn add @design-systems/proof@2.5.5-canary.552.10716.0
  yarn add @design-systems/size@2.5.5-canary.552.10716.0
  yarn add @design-systems/storybook@2.5.5-canary.552.10716.0
  yarn add @design-systems/test@2.5.5-canary.552.10716.0
  yarn add @design-systems/update@2.5.5-canary.552.10716.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
