### PR TITLE
fix: issue committing on windows

### DIFF
--- a/packages/create/src/run.ts
+++ b/packages/create/src/run.ts
@@ -399,7 +399,7 @@ export default async function run(args: CreateArgs) {
         72 * 1000
       );
       execSync(
-        `cd ${config.name} && git add . && git commit --no-verify -m 'Create new design system'`
+        `cd ${config.name} && git add . && git commit --no-verify -m "Create new design system"`
       );
     }
 


### PR DESCRIPTION
- Address issue initializing a new design system on windows
# What Changed
Modified the quotes for the commit message to double quotes

# Why
Resolves #108
Windows apparently doesn't not like single quotes.  A unix system can accept either.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.1-canary.558.10825.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.6.1-canary.558.10825.0
  npm install @design-systems/babel-plugin-replace-styles@2.6.1-canary.558.10825.0
  npm install @design-systems/cli-utils@2.6.1-canary.558.10825.0
  npm install @design-systems/cli@2.6.1-canary.558.10825.0
  npm install @design-systems/core@2.6.1-canary.558.10825.0
  npm install @design-systems/create@2.6.1-canary.558.10825.0
  npm install @design-systems/docs@2.6.1-canary.558.10825.0
  npm install @design-systems/eslint-config@2.6.1-canary.558.10825.0
  npm install @design-systems/load-config@2.6.1-canary.558.10825.0
  npm install @design-systems/next-esm-css@2.6.1-canary.558.10825.0
  npm install @design-systems/plugin@2.6.1-canary.558.10825.0
  npm install @design-systems/stylelint-config@2.6.1-canary.558.10825.0
  npm install @design-systems/utils@2.6.1-canary.558.10825.0
  npm install @design-systems/build@2.6.1-canary.558.10825.0
  npm install @design-systems/bundle@2.6.1-canary.558.10825.0
  npm install @design-systems/clean@2.6.1-canary.558.10825.0
  npm install @design-systems/create-command@2.6.1-canary.558.10825.0
  npm install @design-systems/dev@2.6.1-canary.558.10825.0
  npm install @design-systems/lint@2.6.1-canary.558.10825.0
  npm install @design-systems/playroom@2.6.1-canary.558.10825.0
  npm install @design-systems/proof@2.6.1-canary.558.10825.0
  npm install @design-systems/size@2.6.1-canary.558.10825.0
  npm install @design-systems/storybook@2.6.1-canary.558.10825.0
  npm install @design-systems/test@2.6.1-canary.558.10825.0
  npm install @design-systems/update@2.6.1-canary.558.10825.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.6.1-canary.558.10825.0
  yarn add @design-systems/babel-plugin-replace-styles@2.6.1-canary.558.10825.0
  yarn add @design-systems/cli-utils@2.6.1-canary.558.10825.0
  yarn add @design-systems/cli@2.6.1-canary.558.10825.0
  yarn add @design-systems/core@2.6.1-canary.558.10825.0
  yarn add @design-systems/create@2.6.1-canary.558.10825.0
  yarn add @design-systems/docs@2.6.1-canary.558.10825.0
  yarn add @design-systems/eslint-config@2.6.1-canary.558.10825.0
  yarn add @design-systems/load-config@2.6.1-canary.558.10825.0
  yarn add @design-systems/next-esm-css@2.6.1-canary.558.10825.0
  yarn add @design-systems/plugin@2.6.1-canary.558.10825.0
  yarn add @design-systems/stylelint-config@2.6.1-canary.558.10825.0
  yarn add @design-systems/utils@2.6.1-canary.558.10825.0
  yarn add @design-systems/build@2.6.1-canary.558.10825.0
  yarn add @design-systems/bundle@2.6.1-canary.558.10825.0
  yarn add @design-systems/clean@2.6.1-canary.558.10825.0
  yarn add @design-systems/create-command@2.6.1-canary.558.10825.0
  yarn add @design-systems/dev@2.6.1-canary.558.10825.0
  yarn add @design-systems/lint@2.6.1-canary.558.10825.0
  yarn add @design-systems/playroom@2.6.1-canary.558.10825.0
  yarn add @design-systems/proof@2.6.1-canary.558.10825.0
  yarn add @design-systems/size@2.6.1-canary.558.10825.0
  yarn add @design-systems/storybook@2.6.1-canary.558.10825.0
  yarn add @design-systems/test@2.6.1-canary.558.10825.0
  yarn add @design-systems/update@2.6.1-canary.558.10825.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
