### PR TITLE
allowing more then one Component to be passed in to styled

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -379,7 +379,7 @@ all the same props as the element prop.
 
 **Parameters:**
 
-- element (`T | [T, Component<{}, {}, any>[]]`) - The html dom element to create a Component for
+- element (`T | [T, ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)>) | (new (props: any) => Component<any, any, any>)>[]]`) - The html dom element to create a Component for
 - options (`string | WrappedComponent`) - The class an metadata to attach to the Component
 
 **returns:** DocGen & Slotted & WithRef

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -379,7 +379,7 @@ all the same props as the element prop.
 
 **Parameters:**
 
-- element (`T | [T, ReactNode[]]`) - The html dom element to create a Component for
+- element (`T | [T, ...ReactNode[]]`) - The html dom element to create a Component for
 - options (`string | WrappedComponent`) - The class an metadata to attach to the Component
 
 **returns:** DocGen & Slotted & WithRef

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -379,7 +379,7 @@ all the same props as the element prop.
 
 **Parameters:**
 
-- element (`T | [T, ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)>) | (new (props: any) => Component<any, any, any>)>[]]`) - The html dom element to create a Component for
+- element (`T | [T, ReactNode[]]`) - The html dom element to create a Component for
 - options (`string | WrappedComponent`) - The class an metadata to attach to the Component
 
 **returns:** DocGen & Slotted & WithRef

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -379,7 +379,7 @@ all the same props as the element prop.
 
 **Parameters:**
 
-- element (`T`) - The html dom element to create a Component for
+- element (`T | [T, Component<{}, {}, any>[]]`) - The html dom element to create a Component for
 - options (`string | WrappedComponent`) - The class an metadata to attach to the Component
 
 **returns:** DocGen & Slotted & WithRef

--- a/packages/utils/src/utils/styled.tsx
+++ b/packages/utils/src/utils/styled.tsx
@@ -49,7 +49,7 @@ interface WrappedComponent {
  * }
  */
 export function styled<T extends keyof JSX.IntrinsicElements>(
-  element:  T | [T, React.ReactElement[]],
+  element:  T | [T, React.ReactNode[]],
   options: string | WrappedComponent
 ) {
   const defaultDescription = `This component accepts all HTML attributes for a "${element}" element.`;

--- a/packages/utils/src/utils/styled.tsx
+++ b/packages/utils/src/utils/styled.tsx
@@ -49,7 +49,7 @@ interface WrappedComponent {
  * }
  */
 export function styled<T extends keyof JSX.IntrinsicElements>(
-  element:  T | [T, React.Component[]],
+  element:  T | [T, React.ReactElement[]],
   options: string | WrappedComponent
 ) {
   const defaultDescription = `This component accepts all HTML attributes for a "${element}" element.`;

--- a/packages/utils/src/utils/styled.tsx
+++ b/packages/utils/src/utils/styled.tsx
@@ -49,7 +49,7 @@ interface WrappedComponent {
  * }
  */
 export function styled<T extends keyof JSX.IntrinsicElements>(
-  element:  T | [T, React.ReactNode[]],
+  element:  T | [T, ...React.ReactNode[]],
   options: string | WrappedComponent
 ) {
   const defaultDescription = `This component accepts all HTML attributes for a "${element}" element.`;

--- a/packages/utils/src/utils/styled.tsx
+++ b/packages/utils/src/utils/styled.tsx
@@ -49,7 +49,8 @@ interface WrappedComponent {
  * }
  */
 export function styled<T extends keyof JSX.IntrinsicElements>(
-  element: T,
+  element:  T | [T, React.Component[]],,
+  element:  T | [T, React.Component[]],,
   options: string | WrappedComponent
 ) {
   const defaultDescription = `This component accepts all HTML attributes for a "${element}" element.`;
@@ -67,10 +68,14 @@ export function styled<T extends keyof JSX.IntrinsicElements>(
     React.PropsWithoutRef<Props> & React.RefAttributes<HTMLElement>
   >;
 
+  const elements = Array.isArray(element) ? element : [element];
+
   /** The result "styled" component. */
   const Wrapped = React.forwardRef<HTMLElement, Props>((props, ref) => {
-    const { as, ...rest } = props;
-    const Component = (as || element) as any;
+    const { as,  ...rest } = props;
+
+    const [component, ...innerElements] = elements as any;
+    const Component = as || component;
 
     return (
       <Component
@@ -78,13 +83,19 @@ export function styled<T extends keyof JSX.IntrinsicElements>(
         {...rest}
         className={makeClass(className, (props as any).className)}
       >
-        {props.children}
+        {innerElements.length
+          ? innerElements
+              .reverse()
+              .reduce((Children: React.ReactChildren, Parent: any) => {
+                return <Parent> {Children} </Parent>;
+              }, props.children)
+          : props.children}
       </Component>
     );
   }) as DocGen & Slotted & WithRef;
 
   // eslint-disable-next-line no-underscore-dangle
-  Wrapped._SLOT_ = slot || Symbol(element);
+  Wrapped._SLOT_ = slot || Symbol(elements[0]);
   Wrapped.displayName = name;
   // eslint-disable-next-line no-underscore-dangle
   Wrapped.__docgenInfo = {

--- a/packages/utils/src/utils/styled.tsx
+++ b/packages/utils/src/utils/styled.tsx
@@ -49,8 +49,7 @@ interface WrappedComponent {
  * }
  */
 export function styled<T extends keyof JSX.IntrinsicElements>(
-  element:  T | [T, React.Component[]],,
-  element:  T | [T, React.Component[]],,
+  element:  T | [T, React.Component[]],
   options: string | WrappedComponent
 ) {
   const defaultDescription = `This component accepts all HTML attributes for a "${element}" element.`;


### PR DESCRIPTION
I want to be able to pass in an array of elements. I don't want to break the `as` prop so I am trying to make a tuple

This:
```
const Label = styled(
  ['label', B3, Demi],
  {
    class: styles.label,
    name: "BigNumber.Label",
    description: "The label for the big number",
  }
)
```
should turn into:
```
<label>
   <B3>
      <Demi>
          {Children}
      </Demi>
   </B3>
</label>
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.2-canary.577.11144.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.6.2-canary.577.11144.0
  npm install @design-systems/babel-plugin-replace-styles@2.6.2-canary.577.11144.0
  npm install @design-systems/cli-utils@2.6.2-canary.577.11144.0
  npm install @design-systems/cli@2.6.2-canary.577.11144.0
  npm install @design-systems/core@2.6.2-canary.577.11144.0
  npm install @design-systems/create@2.6.2-canary.577.11144.0
  npm install @design-systems/docs@2.6.2-canary.577.11144.0
  npm install @design-systems/eslint-config@2.6.2-canary.577.11144.0
  npm install @design-systems/load-config@2.6.2-canary.577.11144.0
  npm install @design-systems/next-esm-css@2.6.2-canary.577.11144.0
  npm install @design-systems/plugin@2.6.2-canary.577.11144.0
  npm install @design-systems/stylelint-config@2.6.2-canary.577.11144.0
  npm install @design-systems/utils@2.6.2-canary.577.11144.0
  npm install @design-systems/build@2.6.2-canary.577.11144.0
  npm install @design-systems/bundle@2.6.2-canary.577.11144.0
  npm install @design-systems/clean@2.6.2-canary.577.11144.0
  npm install @design-systems/create-command@2.6.2-canary.577.11144.0
  npm install @design-systems/dev@2.6.2-canary.577.11144.0
  npm install @design-systems/lint@2.6.2-canary.577.11144.0
  npm install @design-systems/playroom@2.6.2-canary.577.11144.0
  npm install @design-systems/proof@2.6.2-canary.577.11144.0
  npm install @design-systems/size@2.6.2-canary.577.11144.0
  npm install @design-systems/storybook@2.6.2-canary.577.11144.0
  npm install @design-systems/test@2.6.2-canary.577.11144.0
  npm install @design-systems/update@2.6.2-canary.577.11144.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.6.2-canary.577.11144.0
  yarn add @design-systems/babel-plugin-replace-styles@2.6.2-canary.577.11144.0
  yarn add @design-systems/cli-utils@2.6.2-canary.577.11144.0
  yarn add @design-systems/cli@2.6.2-canary.577.11144.0
  yarn add @design-systems/core@2.6.2-canary.577.11144.0
  yarn add @design-systems/create@2.6.2-canary.577.11144.0
  yarn add @design-systems/docs@2.6.2-canary.577.11144.0
  yarn add @design-systems/eslint-config@2.6.2-canary.577.11144.0
  yarn add @design-systems/load-config@2.6.2-canary.577.11144.0
  yarn add @design-systems/next-esm-css@2.6.2-canary.577.11144.0
  yarn add @design-systems/plugin@2.6.2-canary.577.11144.0
  yarn add @design-systems/stylelint-config@2.6.2-canary.577.11144.0
  yarn add @design-systems/utils@2.6.2-canary.577.11144.0
  yarn add @design-systems/build@2.6.2-canary.577.11144.0
  yarn add @design-systems/bundle@2.6.2-canary.577.11144.0
  yarn add @design-systems/clean@2.6.2-canary.577.11144.0
  yarn add @design-systems/create-command@2.6.2-canary.577.11144.0
  yarn add @design-systems/dev@2.6.2-canary.577.11144.0
  yarn add @design-systems/lint@2.6.2-canary.577.11144.0
  yarn add @design-systems/playroom@2.6.2-canary.577.11144.0
  yarn add @design-systems/proof@2.6.2-canary.577.11144.0
  yarn add @design-systems/size@2.6.2-canary.577.11144.0
  yarn add @design-systems/storybook@2.6.2-canary.577.11144.0
  yarn add @design-systems/test@2.6.2-canary.577.11144.0
  yarn add @design-systems/update@2.6.2-canary.577.11144.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
