### PR TITLE
fix css source map generation

### DIFF
--- a/plugins/build/src/index.ts
+++ b/plugins/build/src/index.ts
@@ -208,7 +208,7 @@ export default class BuildPlugin implements Plugin<BuildArgs> {
         ${difference} -${efficiency}% ${duration}\n
       `);
 
-        await fs.outputFile(`${outFile}.map`, minified.sourceMap);
+        await fs.outputFile(`${outFile}.map`, minified.sourceMap.toString());
         await fs.outputFile(
           outFile,
           `${minified.styles}\n/*# sourceMappingURL=${makeCSSFilename(


### PR DESCRIPTION
# What Changed

clean-css is return the source map generator, which errors if we try to write it to a file. calling `toString` fixes this

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.7.2-canary.580.11504.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.7.2-canary.580.11504.0
  npm install @design-systems/babel-plugin-replace-styles@2.7.2-canary.580.11504.0
  npm install @design-systems/cli-utils@2.7.2-canary.580.11504.0
  npm install @design-systems/cli@2.7.2-canary.580.11504.0
  npm install @design-systems/core@2.7.2-canary.580.11504.0
  npm install @design-systems/create@2.7.2-canary.580.11504.0
  npm install @design-systems/docs@2.7.2-canary.580.11504.0
  npm install @design-systems/eslint-config@2.7.2-canary.580.11504.0
  npm install @design-systems/load-config@2.7.2-canary.580.11504.0
  npm install @design-systems/next-esm-css@2.7.2-canary.580.11504.0
  npm install @design-systems/plugin@2.7.2-canary.580.11504.0
  npm install @design-systems/stylelint-config@2.7.2-canary.580.11504.0
  npm install @design-systems/utils@2.7.2-canary.580.11504.0
  npm install @design-systems/build@2.7.2-canary.580.11504.0
  npm install @design-systems/bundle@2.7.2-canary.580.11504.0
  npm install @design-systems/clean@2.7.2-canary.580.11504.0
  npm install @design-systems/create-command@2.7.2-canary.580.11504.0
  npm install @design-systems/dev@2.7.2-canary.580.11504.0
  npm install @design-systems/lint@2.7.2-canary.580.11504.0
  npm install @design-systems/playroom@2.7.2-canary.580.11504.0
  npm install @design-systems/proof@2.7.2-canary.580.11504.0
  npm install @design-systems/size@2.7.2-canary.580.11504.0
  npm install @design-systems/storybook@2.7.2-canary.580.11504.0
  npm install @design-systems/test@2.7.2-canary.580.11504.0
  npm install @design-systems/update@2.7.2-canary.580.11504.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.7.2-canary.580.11504.0
  yarn add @design-systems/babel-plugin-replace-styles@2.7.2-canary.580.11504.0
  yarn add @design-systems/cli-utils@2.7.2-canary.580.11504.0
  yarn add @design-systems/cli@2.7.2-canary.580.11504.0
  yarn add @design-systems/core@2.7.2-canary.580.11504.0
  yarn add @design-systems/create@2.7.2-canary.580.11504.0
  yarn add @design-systems/docs@2.7.2-canary.580.11504.0
  yarn add @design-systems/eslint-config@2.7.2-canary.580.11504.0
  yarn add @design-systems/load-config@2.7.2-canary.580.11504.0
  yarn add @design-systems/next-esm-css@2.7.2-canary.580.11504.0
  yarn add @design-systems/plugin@2.7.2-canary.580.11504.0
  yarn add @design-systems/stylelint-config@2.7.2-canary.580.11504.0
  yarn add @design-systems/utils@2.7.2-canary.580.11504.0
  yarn add @design-systems/build@2.7.2-canary.580.11504.0
  yarn add @design-systems/bundle@2.7.2-canary.580.11504.0
  yarn add @design-systems/clean@2.7.2-canary.580.11504.0
  yarn add @design-systems/create-command@2.7.2-canary.580.11504.0
  yarn add @design-systems/dev@2.7.2-canary.580.11504.0
  yarn add @design-systems/lint@2.7.2-canary.580.11504.0
  yarn add @design-systems/playroom@2.7.2-canary.580.11504.0
  yarn add @design-systems/proof@2.7.2-canary.580.11504.0
  yarn add @design-systems/size@2.7.2-canary.580.11504.0
  yarn add @design-systems/storybook@2.7.2-canary.580.11504.0
  yarn add @design-systems/test@2.7.2-canary.580.11504.0
  yarn add @design-systems/update@2.7.2-canary.580.11504.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
