### PR TITLE
adds jsx to jest moduleFileExtension list

### DIFF
--- a/plugins/test/src/jest.config.base.ts
+++ b/plugins/test/src/jest.config.base.ts
@@ -9,7 +9,7 @@ module.exports = {
   ],
   collectCoverage: true,
   verbose: true,
-  moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
+  moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],
   setupFiles: [path.join(__dirname, './jest/setupTests.js')],
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '/helpers/'],
   moduleNameMapper: {


### PR DESCRIPTION
# What Changed
Adds jsx to moduleFileExtension list in jest config
# Why
So that test plugin supports components written with the jsx file extension

Todo:

- [N/A] Add tests
- [N/A] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.7.4-canary.583.11812.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.7.4-canary.583.11812.0
  npm install @design-systems/babel-plugin-replace-styles@2.7.4-canary.583.11812.0
  npm install @design-systems/cli-utils@2.7.4-canary.583.11812.0
  npm install @design-systems/cli@2.7.4-canary.583.11812.0
  npm install @design-systems/core@2.7.4-canary.583.11812.0
  npm install @design-systems/create@2.7.4-canary.583.11812.0
  npm install @design-systems/docs@2.7.4-canary.583.11812.0
  npm install @design-systems/eslint-config@2.7.4-canary.583.11812.0
  npm install @design-systems/load-config@2.7.4-canary.583.11812.0
  npm install @design-systems/next-esm-css@2.7.4-canary.583.11812.0
  npm install @design-systems/plugin@2.7.4-canary.583.11812.0
  npm install @design-systems/stylelint-config@2.7.4-canary.583.11812.0
  npm install @design-systems/utils@2.7.4-canary.583.11812.0
  npm install @design-systems/build@2.7.4-canary.583.11812.0
  npm install @design-systems/bundle@2.7.4-canary.583.11812.0
  npm install @design-systems/clean@2.7.4-canary.583.11812.0
  npm install @design-systems/create-command@2.7.4-canary.583.11812.0
  npm install @design-systems/dev@2.7.4-canary.583.11812.0
  npm install @design-systems/lint@2.7.4-canary.583.11812.0
  npm install @design-systems/playroom@2.7.4-canary.583.11812.0
  npm install @design-systems/proof@2.7.4-canary.583.11812.0
  npm install @design-systems/size@2.7.4-canary.583.11812.0
  npm install @design-systems/storybook@2.7.4-canary.583.11812.0
  npm install @design-systems/test@2.7.4-canary.583.11812.0
  npm install @design-systems/update@2.7.4-canary.583.11812.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.7.4-canary.583.11812.0
  yarn add @design-systems/babel-plugin-replace-styles@2.7.4-canary.583.11812.0
  yarn add @design-systems/cli-utils@2.7.4-canary.583.11812.0
  yarn add @design-systems/cli@2.7.4-canary.583.11812.0
  yarn add @design-systems/core@2.7.4-canary.583.11812.0
  yarn add @design-systems/create@2.7.4-canary.583.11812.0
  yarn add @design-systems/docs@2.7.4-canary.583.11812.0
  yarn add @design-systems/eslint-config@2.7.4-canary.583.11812.0
  yarn add @design-systems/load-config@2.7.4-canary.583.11812.0
  yarn add @design-systems/next-esm-css@2.7.4-canary.583.11812.0
  yarn add @design-systems/plugin@2.7.4-canary.583.11812.0
  yarn add @design-systems/stylelint-config@2.7.4-canary.583.11812.0
  yarn add @design-systems/utils@2.7.4-canary.583.11812.0
  yarn add @design-systems/build@2.7.4-canary.583.11812.0
  yarn add @design-systems/bundle@2.7.4-canary.583.11812.0
  yarn add @design-systems/clean@2.7.4-canary.583.11812.0
  yarn add @design-systems/create-command@2.7.4-canary.583.11812.0
  yarn add @design-systems/dev@2.7.4-canary.583.11812.0
  yarn add @design-systems/lint@2.7.4-canary.583.11812.0
  yarn add @design-systems/playroom@2.7.4-canary.583.11812.0
  yarn add @design-systems/proof@2.7.4-canary.583.11812.0
  yarn add @design-systems/size@2.7.4-canary.583.11812.0
  yarn add @design-systems/storybook@2.7.4-canary.583.11812.0
  yarn add @design-systems/test@2.7.4-canary.583.11812.0
  yarn add @design-systems/update@2.7.4-canary.583.11812.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
