### PR TITLE
allow `styled` util to take a react component

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -379,7 +379,7 @@ all the same props as the element prop.
 
 **Parameters:**
 
-- element (`T | [T, ...((props: any) => ReactNode)[]]`) - The html dom element to create a Component for
+- element (`T | [T, ...JSXElementConstructor<unknown>[]]`) - The html dom element or React component to create a Component for
 - options (`string | WrappedComponent`) - The class an metadata to attach to the Component
 
 **returns:** DocGen & Slotted & WithRef

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -51,8 +51,10 @@ export declare type Require<T, K extends keyof T> = T & Required<Pick<T, K>>;
  * )
  */
 export type Element<
-  T extends keyof JSX.IntrinsicElements
-> = React.PropsWithoutRef<JSX.IntrinsicElements[T]>;
+  T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<unknown>
+> = T extends keyof JSX.IntrinsicElements
+  ? React.PropsWithoutRef<JSX.IntrinsicElements[T]>
+  : React.ComponentProps<T>;
 
 /**
  * Create an interface that has all the properties of the input

--- a/packages/utils/src/utils/styled.tsx
+++ b/packages/utils/src/utils/styled.tsx
@@ -32,7 +32,7 @@ interface WrappedComponent {
  * Create a react element with a className attached. The generated element accepts
  * all the same props as the element prop.
  *
- * @param element - The html dom element to create a Component for
+ * @param element - The html dom element or React component to create a Component for
  * @param options - The class an metadata to attach to the Component
  *
  * @example
@@ -49,8 +49,10 @@ interface WrappedComponent {
  *   </Wrapper>
  * }
  */
-export function styled<T extends keyof JSX.IntrinsicElements>(
-  element: T | [T, ...((props: any) => React.ReactNode)[]],
+export function styled<
+  T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<unknown>
+>(
+  element: T | [T, ...React.JSXElementConstructor<unknown>[]],
   options: string | WrappedComponent
 ) {
   const defaultDescription = `This component accepts all HTML attributes for a "${element}" element.`;
@@ -80,23 +82,25 @@ export function styled<T extends keyof JSX.IntrinsicElements>(
   )) as any;
 
   /** The result "styled" component. */
-  const Wrapped = React.forwardRef<HTMLElement, Props>((props, ref) => {
-    const { as, ...rest } = props;
+  const Wrapped = React.forwardRef(
+    (props: Props, ref: React.Ref<HTMLElement>) => {
+      const { as, ...rest } = props as any;
 
-    /* If more then one component comes reduce into one component */
-    const Component = as || ElementsReduced;
+      /* If more then one component comes reduce into one component */
+      const Component = as || ElementsReduced;
 
-    return (
-      <Component
-        ref={ref}
-        {...rest}
-        className={makeClass(className, (props as any).className)}
-      />
-    );
-  }) as DocGen & Slotted & WithRef;
+      return (
+        <Component
+          ref={ref}
+          {...rest}
+          className={makeClass(className, (props as any).className)}
+        />
+      );
+    }
+  ) as DocGen & Slotted & WithRef;
 
   // eslint-disable-next-line no-underscore-dangle
-  Wrapped._SLOT_ = slot || Symbol(elements[0]);
+  Wrapped._SLOT_ = slot || Symbol('component slot');
   Wrapped.displayName = name;
   // eslint-disable-next-line no-underscore-dangle
   Wrapped.__docgenInfo = {


### PR DESCRIPTION
# What Changed

see title

# Why

This way a component can easily add a class to another components sub-component



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.8.1-canary.591.12519.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.8.1-canary.591.12519.0
  npm install @design-systems/babel-plugin-replace-styles@2.8.1-canary.591.12519.0
  npm install @design-systems/cli-utils@2.8.1-canary.591.12519.0
  npm install @design-systems/cli@2.8.1-canary.591.12519.0
  npm install @design-systems/core@2.8.1-canary.591.12519.0
  npm install @design-systems/create@2.8.1-canary.591.12519.0
  npm install @design-systems/docs@2.8.1-canary.591.12519.0
  npm install @design-systems/eslint-config@2.8.1-canary.591.12519.0
  npm install @design-systems/load-config@2.8.1-canary.591.12519.0
  npm install @design-systems/next-esm-css@2.8.1-canary.591.12519.0
  npm install @design-systems/plugin@2.8.1-canary.591.12519.0
  npm install @design-systems/stylelint-config@2.8.1-canary.591.12519.0
  npm install @design-systems/utils@2.8.1-canary.591.12519.0
  npm install @design-systems/build@2.8.1-canary.591.12519.0
  npm install @design-systems/bundle@2.8.1-canary.591.12519.0
  npm install @design-systems/clean@2.8.1-canary.591.12519.0
  npm install @design-systems/create-command@2.8.1-canary.591.12519.0
  npm install @design-systems/dev@2.8.1-canary.591.12519.0
  npm install @design-systems/lint@2.8.1-canary.591.12519.0
  npm install @design-systems/playroom@2.8.1-canary.591.12519.0
  npm install @design-systems/proof@2.8.1-canary.591.12519.0
  npm install @design-systems/size@2.8.1-canary.591.12519.0
  npm install @design-systems/storybook@2.8.1-canary.591.12519.0
  npm install @design-systems/test@2.8.1-canary.591.12519.0
  npm install @design-systems/update@2.8.1-canary.591.12519.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.8.1-canary.591.12519.0
  yarn add @design-systems/babel-plugin-replace-styles@2.8.1-canary.591.12519.0
  yarn add @design-systems/cli-utils@2.8.1-canary.591.12519.0
  yarn add @design-systems/cli@2.8.1-canary.591.12519.0
  yarn add @design-systems/core@2.8.1-canary.591.12519.0
  yarn add @design-systems/create@2.8.1-canary.591.12519.0
  yarn add @design-systems/docs@2.8.1-canary.591.12519.0
  yarn add @design-systems/eslint-config@2.8.1-canary.591.12519.0
  yarn add @design-systems/load-config@2.8.1-canary.591.12519.0
  yarn add @design-systems/next-esm-css@2.8.1-canary.591.12519.0
  yarn add @design-systems/plugin@2.8.1-canary.591.12519.0
  yarn add @design-systems/stylelint-config@2.8.1-canary.591.12519.0
  yarn add @design-systems/utils@2.8.1-canary.591.12519.0
  yarn add @design-systems/build@2.8.1-canary.591.12519.0
  yarn add @design-systems/bundle@2.8.1-canary.591.12519.0
  yarn add @design-systems/clean@2.8.1-canary.591.12519.0
  yarn add @design-systems/create-command@2.8.1-canary.591.12519.0
  yarn add @design-systems/dev@2.8.1-canary.591.12519.0
  yarn add @design-systems/lint@2.8.1-canary.591.12519.0
  yarn add @design-systems/playroom@2.8.1-canary.591.12519.0
  yarn add @design-systems/proof@2.8.1-canary.591.12519.0
  yarn add @design-systems/size@2.8.1-canary.591.12519.0
  yarn add @design-systems/storybook@2.8.1-canary.591.12519.0
  yarn add @design-systems/test@2.8.1-canary.591.12519.0
  yarn add @design-systems/update@2.8.1-canary.591.12519.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
