### PR TITLE
move types packages to devDependencies

### DIFF
--- a/plugins/bundle/package.json
+++ b/plugins/bundle/package.json
@@ -22,8 +22,6 @@
     "@design-systems/build": "link:../build",
     "@design-systems/cli-utils": "link:../../packages/cli-utils",
     "@design-systems/plugin": "link:../../packages/plugin",
-    "@types/case-sensitive-paths-webpack-plugin": "2.1.4",
-    "@types/duplicate-package-checker-webpack-plugin": "2.1.0",
     "case-sensitive-paths-webpack-plugin": "2.3.0",
     "dedent": "0.7.0",
     "duplicate-package-checker-webpack-plugin": "3.0.0",
@@ -33,5 +31,9 @@
     "terser-webpack-plugin": "4.1.0",
     "tslib": "2.0.1",
     "webpack": "4.44.1"
+  },
+  "devDependencies": {
+    "@types/case-sensitive-paths-webpack-plugin": "2.1.4",
+    "@types/duplicate-package-checker-webpack-plugin": "2.1.0"
   }
 }


### PR DESCRIPTION
# What Changed

Moving `@types` packages to `devDependencies`.

# Why

Prevent collisions when using `tapable` as a core dependency, since `tapable@2` and up have different exports than those required by the `@types/webpack` package.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.8.1-canary.593.12615.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.8.1-canary.593.12615.0
  npm install @design-systems/babel-plugin-replace-styles@2.8.1-canary.593.12615.0
  npm install @design-systems/cli-utils@2.8.1-canary.593.12615.0
  npm install @design-systems/cli@2.8.1-canary.593.12615.0
  npm install @design-systems/core@2.8.1-canary.593.12615.0
  npm install @design-systems/create@2.8.1-canary.593.12615.0
  npm install @design-systems/docs@2.8.1-canary.593.12615.0
  npm install @design-systems/eslint-config@2.8.1-canary.593.12615.0
  npm install @design-systems/load-config@2.8.1-canary.593.12615.0
  npm install @design-systems/next-esm-css@2.8.1-canary.593.12615.0
  npm install @design-systems/plugin@2.8.1-canary.593.12615.0
  npm install @design-systems/stylelint-config@2.8.1-canary.593.12615.0
  npm install @design-systems/utils@2.8.1-canary.593.12615.0
  npm install @design-systems/build@2.8.1-canary.593.12615.0
  npm install @design-systems/bundle@2.8.1-canary.593.12615.0
  npm install @design-systems/clean@2.8.1-canary.593.12615.0
  npm install @design-systems/create-command@2.8.1-canary.593.12615.0
  npm install @design-systems/dev@2.8.1-canary.593.12615.0
  npm install @design-systems/lint@2.8.1-canary.593.12615.0
  npm install @design-systems/playroom@2.8.1-canary.593.12615.0
  npm install @design-systems/proof@2.8.1-canary.593.12615.0
  npm install @design-systems/size@2.8.1-canary.593.12615.0
  npm install @design-systems/storybook@2.8.1-canary.593.12615.0
  npm install @design-systems/test@2.8.1-canary.593.12615.0
  npm install @design-systems/update@2.8.1-canary.593.12615.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.8.1-canary.593.12615.0
  yarn add @design-systems/babel-plugin-replace-styles@2.8.1-canary.593.12615.0
  yarn add @design-systems/cli-utils@2.8.1-canary.593.12615.0
  yarn add @design-systems/cli@2.8.1-canary.593.12615.0
  yarn add @design-systems/core@2.8.1-canary.593.12615.0
  yarn add @design-systems/create@2.8.1-canary.593.12615.0
  yarn add @design-systems/docs@2.8.1-canary.593.12615.0
  yarn add @design-systems/eslint-config@2.8.1-canary.593.12615.0
  yarn add @design-systems/load-config@2.8.1-canary.593.12615.0
  yarn add @design-systems/next-esm-css@2.8.1-canary.593.12615.0
  yarn add @design-systems/plugin@2.8.1-canary.593.12615.0
  yarn add @design-systems/stylelint-config@2.8.1-canary.593.12615.0
  yarn add @design-systems/utils@2.8.1-canary.593.12615.0
  yarn add @design-systems/build@2.8.1-canary.593.12615.0
  yarn add @design-systems/bundle@2.8.1-canary.593.12615.0
  yarn add @design-systems/clean@2.8.1-canary.593.12615.0
  yarn add @design-systems/create-command@2.8.1-canary.593.12615.0
  yarn add @design-systems/dev@2.8.1-canary.593.12615.0
  yarn add @design-systems/lint@2.8.1-canary.593.12615.0
  yarn add @design-systems/playroom@2.8.1-canary.593.12615.0
  yarn add @design-systems/proof@2.8.1-canary.593.12615.0
  yarn add @design-systems/size@2.8.1-canary.593.12615.0
  yarn add @design-systems/storybook@2.8.1-canary.593.12615.0
  yarn add @design-systems/test@2.8.1-canary.593.12615.0
  yarn add @design-systems/update@2.8.1-canary.593.12615.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
