### PR TITLE
Update playroom

### DIFF
--- a/plugins/playroom/package.json
+++ b/plugins/playroom/package.json
@@ -30,7 +30,7 @@
     "fast-glob": "3.2.4",
     "file-loader": "6.1.0",
     "fs-extra": "9.0.1",
-    "playroom": "0.21.3",
+    "playroom": "0.22.3",
     "react-element-to-jsx-string": "14.3.1",
     "style-loader": "1.2.1",
     "tslib": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2170,8 +2170,6 @@
     "@design-systems/build" "link:plugins/build"
     "@design-systems/cli-utils" "link:packages/cli-utils"
     "@design-systems/plugin" "link:packages/plugin"
-    "@types/case-sensitive-paths-webpack-plugin" "2.1.4"
-    "@types/duplicate-package-checker-webpack-plugin" "2.1.0"
     case-sensitive-paths-webpack-plugin "2.3.0"
     dedent "0.7.0"
     duplicate-package-checker-webpack-plugin "3.0.0"


### PR DESCRIPTION
# What Changed

Update playroom to latest version.

# Why

Removes two `@types` dependencies which conflict when using `tapable` as a core dependency.
