### PR TITLE
add .md to identity-obj-proxy

### DIFF
--- a/plugins/test/src/jest.config.base.ts
+++ b/plugins/test/src/jest.config.base.ts
@@ -13,7 +13,7 @@ module.exports = {
   setupFiles: [path.join(__dirname, './jest/setupTests.js')],
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '/helpers/'],
   moduleNameMapper: {
-    '\\.css$': 'identity-obj-proxy'
+    '\\.(css|md)$': 'identity-obj-proxy'
   },
   transform: {
     '\\.(js|jsx|ts|tsx)$': path.join(__dirname, './jest/transform.js')


### PR DESCRIPTION
# What Changed
- allow jest to handle importing of markdown files without erroring
# Why
- our workflow is to write unit tests against our component stories. storybook files generated by `ds create` by default import a `.md` file, which throws an error when we import our story into a `.test` file. adding `md` to `moduleNameMapper` config fixes this

Todo:

- [ ] Add tests
- [ ] Add docs
