### PR TITLE
add moduleHash option for postcss configs

### DIFF
--- a/plugins/build/src/command.ts
+++ b/plugins/build/src/command.ts
@@ -133,6 +133,27 @@ const command: CliCommand = {
         \`\`\`
       `,
     },
+    {
+      header: 'Module Hash',
+      content: [
+        dedent`
+          If you are doing multi build css you might want to use our postcss config's \`moduleHash\` option.
+          This option will be added to the classnames that are produced so that if the application loads the single theme and multi-theme version of you component the classNames won't clash.
+        `,
+      ],
+    },
+    {
+      code: true,
+      content: dedent`
+        \`\`\`js
+        const defaultConfig = require('@design-systems/build/postcss.config');
+
+        module.exports = (ctx) => {
+          return defaultConfig({ ...ctx, moduleHash: 'my-theme' })
+        });
+        \`\`\`
+      `,
+    },
   ],
 };
 

--- a/plugins/build/src/configs/postcss.config.ts
+++ b/plugins/build/src/configs/postcss.config.ts
@@ -11,9 +11,10 @@ import pkgUp from 'pkg-up';
 interface PostCSSContext {
   env?: string;
   outDir: string;
+  moduleHash?: string;
 }
 
-module.exports = function(ctx: PostCSSContext = { outDir: 'dist' }) {
+module.exports = function (ctx: PostCSSContext = { outDir: 'dist' }) {
   return {
     plugins: [
       nested,
@@ -32,6 +33,10 @@ module.exports = function(ctx: PostCSSContext = { outDir: 'dist' }) {
             .update(base)
             .update(name)
             .update(css);
+
+          if (ctx.moduleHash) {
+            hash.update(ctx.moduleHash);
+          }
 
           if (pkgJson) {
             try {
@@ -55,14 +60,14 @@ module.exports = function(ctx: PostCSSContext = { outDir: 'dist' }) {
 
             return Promise.all([
               fs.outputFile(cjs, code),
-              fs.outputFile(esm, code)
+              fs.outputFile(esm, code),
             ]);
           }
-        }
+        },
       }),
       hexRGBA,
       autoprefixer,
-      url({ url: 'inline' })
-    ]
+      url({ url: 'inline' }),
+    ],
   };
 };


### PR DESCRIPTION
# What Changed

Add new postcss config option to control the css-modules className hashing

# Why

When doing single theme builds you can get into situations where one team is using the single theme version and another isn't so the theming isn't consistent

Todo:

- [ ] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.9.2-canary.602.13480.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.9.2-canary.602.13480.0
  npm install @design-systems/babel-plugin-replace-styles@2.9.2-canary.602.13480.0
  npm install @design-systems/cli-utils@2.9.2-canary.602.13480.0
  npm install @design-systems/cli@2.9.2-canary.602.13480.0
  npm install @design-systems/core@2.9.2-canary.602.13480.0
  npm install @design-systems/create@2.9.2-canary.602.13480.0
  npm install @design-systems/docs@2.9.2-canary.602.13480.0
  npm install @design-systems/eslint-config@2.9.2-canary.602.13480.0
  npm install @design-systems/load-config@2.9.2-canary.602.13480.0
  npm install @design-systems/next-esm-css@2.9.2-canary.602.13480.0
  npm install @design-systems/plugin@2.9.2-canary.602.13480.0
  npm install @design-systems/stylelint-config@2.9.2-canary.602.13480.0
  npm install @design-systems/utils@2.9.2-canary.602.13480.0
  npm install @design-systems/build@2.9.2-canary.602.13480.0
  npm install @design-systems/bundle@2.9.2-canary.602.13480.0
  npm install @design-systems/clean@2.9.2-canary.602.13480.0
  npm install @design-systems/create-command@2.9.2-canary.602.13480.0
  npm install @design-systems/dev@2.9.2-canary.602.13480.0
  npm install @design-systems/lint@2.9.2-canary.602.13480.0
  npm install @design-systems/playroom@2.9.2-canary.602.13480.0
  npm install @design-systems/proof@2.9.2-canary.602.13480.0
  npm install @design-systems/size@2.9.2-canary.602.13480.0
  npm install @design-systems/storybook@2.9.2-canary.602.13480.0
  npm install @design-systems/test@2.9.2-canary.602.13480.0
  npm install @design-systems/update@2.9.2-canary.602.13480.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.9.2-canary.602.13480.0
  yarn add @design-systems/babel-plugin-replace-styles@2.9.2-canary.602.13480.0
  yarn add @design-systems/cli-utils@2.9.2-canary.602.13480.0
  yarn add @design-systems/cli@2.9.2-canary.602.13480.0
  yarn add @design-systems/core@2.9.2-canary.602.13480.0
  yarn add @design-systems/create@2.9.2-canary.602.13480.0
  yarn add @design-systems/docs@2.9.2-canary.602.13480.0
  yarn add @design-systems/eslint-config@2.9.2-canary.602.13480.0
  yarn add @design-systems/load-config@2.9.2-canary.602.13480.0
  yarn add @design-systems/next-esm-css@2.9.2-canary.602.13480.0
  yarn add @design-systems/plugin@2.9.2-canary.602.13480.0
  yarn add @design-systems/stylelint-config@2.9.2-canary.602.13480.0
  yarn add @design-systems/utils@2.9.2-canary.602.13480.0
  yarn add @design-systems/build@2.9.2-canary.602.13480.0
  yarn add @design-systems/bundle@2.9.2-canary.602.13480.0
  yarn add @design-systems/clean@2.9.2-canary.602.13480.0
  yarn add @design-systems/create-command@2.9.2-canary.602.13480.0
  yarn add @design-systems/dev@2.9.2-canary.602.13480.0
  yarn add @design-systems/lint@2.9.2-canary.602.13480.0
  yarn add @design-systems/playroom@2.9.2-canary.602.13480.0
  yarn add @design-systems/proof@2.9.2-canary.602.13480.0
  yarn add @design-systems/size@2.9.2-canary.602.13480.0
  yarn add @design-systems/storybook@2.9.2-canary.602.13480.0
  yarn add @design-systems/test@2.9.2-canary.602.13480.0
  yarn add @design-systems/update@2.9.2-canary.602.13480.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
