### PR TITLE
integrate JSON file into single css theme builds

### DIFF
--- a/packages/babel-plugin-replace-styles/README.md
+++ b/packages/babel-plugin-replace-styles/README.md
@@ -28,7 +28,7 @@ babel.config.json:
 {
   "plugins": [
     [
-      "@design-systems/babel-plugin-include-styles",
+      "@design-systems/babel-plugin-replace-styles",
       { "scope": "your-ds", "replace": "main", "use": "prefixed" }
     ]
   ]

--- a/packages/babel-plugin-replace-styles/src/__tests__/index.test.ts
+++ b/packages/babel-plugin-replace-styles/src/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import endent from 'endent';
 import { transform } from './helpers/utils';
 import exists from '../exists';
 
@@ -10,16 +11,23 @@ test('should not change css import', () => {
 });
 
 test('should change the import', () => {
-  const source = 'import "../main.css";';
+  const source = `
+    import styles from './Button.css';
+    import "../main.css";
+  `;
   // @ts-ignore
   exists.mockReturnValueOnce(true).mockReturnValueOnce(true);
-  expect(transform(source, '@cgds/dist/test.js')).toBe('import "../test.css";');
+  // @ts-ignore
+  exists.mockReturnValueOnce(true).mockReturnValueOnce(true);
+  expect(transform(source, '@cgds/button/dist/test.js')).toBe(endent`
+    import styles from "./Button-test.css";
+    import "../test.css";
+  `);
 });
-
 
 test('should not change the import if the new file does not exist', () => {
   const source = 'import "../main.css";';
   // @ts-ignore
   exists.mockReturnValueOnce(true).mockReturnValueOnce(false);
-  expect(transform(source, '@cgds/dist/test.js')).toBe('import "../test.css";');
+  expect(transform(source, '@cgds/button/dist/test.js')).toBe('import "../test.css";');
 });

--- a/packages/babel-plugin-replace-styles/src/index.ts
+++ b/packages/babel-plugin-replace-styles/src/index.ts
@@ -62,12 +62,22 @@ export default function replaceStyles(
       state?.file?.opts?.filename &&
       state.file.opts.filename.includes(`@${scope}/`);
 
-    if (isScope && path.node.specifiers.length) {
+    if (
+      isScope &&
+      path.node.specifiers.length &&
+      importName.includes('.css') &&
+      !importName.includes(use)
+    ) {
+      const dirname = nodePath.dirname(state.file.opts.filename as string);
       const newImport = importName.replace('.css', `-${use}.css`);
+      const newImportPath = nodePath.join(dirname, newImport);
 
-      if (exists(newImport)) {
-        // eslint-disable-next-line no-param-reassign
-        path.node.source.value = newImport;
+      if (exists(newImportPath)) {
+        const importDeclaration = types.importDeclaration(
+          path.node.specifiers,
+          types.stringLiteral(newImport)
+        );
+        path.replaceWith(importDeclaration);
       }
     }
   }

--- a/plugins/build/src/command.ts
+++ b/plugins/build/src/command.ts
@@ -133,27 +133,6 @@ const command: CliCommand = {
         \`\`\`
       `,
     },
-    {
-      header: 'Module Hash',
-      content: [
-        dedent`
-          If you are doing multi build css you might want to use our postcss config's \`moduleHash\` option.
-          This option will be added to the classnames that are produced so that if the application loads the single theme and multi-theme version of you component the classNames won't clash.
-        `,
-      ],
-    },
-    {
-      code: true,
-      content: dedent`
-        \`\`\`js
-        const defaultConfig = require('@design-systems/build/postcss.config');
-
-        module.exports = (ctx) => {
-          return defaultConfig({ ...ctx, moduleHash: 'my-theme' })
-        });
-        \`\`\`
-      `,
-    },
   ],
 };
 

--- a/plugins/build/src/index.ts
+++ b/plugins/build/src/index.ts
@@ -243,6 +243,7 @@ export default class BuildPlugin implements Plugin<BuildArgs> {
           // Single PostCSS build
           const CSSMain = this.buildArgs.cssMain;
           this.logger.trace(`Single PostCSS build requested`);
+
           if (!this.cssFiles[CSSMain]) {
             this.logger.trace(`Creating map for ${CSSMain}`);
             this.cssFiles[CSSMain] = new Map<string, postcss.Result>();
@@ -281,6 +282,7 @@ export default class BuildPlugin implements Plugin<BuildArgs> {
             inDir: inputDirectory,
             outDir: outputDirectory,
             configFile: POSTCSS_CONFIG,
+            themeName: config.name,
             multiBuildConfigFile: config.path,
             isCssMain: this.buildArgs.cssMain === config.name,
             watch: this.buildArgs.watch,

--- a/plugins/build/src/postcss.ts
+++ b/plugins/build/src/postcss.ts
@@ -75,6 +75,8 @@ interface LoadOptions {
    * and it doesn't have css (in the typescript build). We don't care about the error.
    */
   reportError?: boolean;
+  /** A multibuild theme name */
+  themeName?: string;
 }
 
 /** Fail the process if the postcss.config has errors */
@@ -97,11 +99,13 @@ export async function getPostCssConfig({
   outDir = 'dist',
   cwd = process.cwd(),
   reportError = true,
+  themeName,
 }: LoadOptions) {
   const context = useModules
     ? {
         env: 'module',
         outDir,
+        moduleHash: themeName,
       }
     : {};
 
@@ -160,6 +164,8 @@ interface TranspileOptions {
   outDir: string;
   /** Where the postcss.config is */
   configFile: string;
+  /** A multibuild theme name */
+  themeName?: string;
   /** A multibuild config file to use if not overridden */
   multiBuildConfigFile?: string;
   /** If this css file represents everything */
@@ -181,6 +187,7 @@ export default async function transpile({
   isCssMain,
   outDir,
   configFile,
+  themeName,
   multiBuildConfigFile,
   watch,
 }: TranspileOptions): Promise<postcss.Result | void> {
@@ -191,6 +198,7 @@ export default async function transpile({
     configFile,
     multiBuildConfigFile,
     outDir,
+    themeName,
   });
 
   const processor = postcss(plugins);
@@ -200,7 +208,7 @@ export default async function transpile({
     const result = await processor.process(fileContents, {
       ...options,
       plugins,
-      to: isCssMain ? cssFile : undefined,
+      to: isCssMain ? cssFile : cssFile.replace('.css', `-${themeName}.css`),
       from: inFile,
       map: { inline: false },
     });


### PR DESCRIPTION
# What Changed

The previous PR would break the default (all themes) build and none of the theme json would match up leading to unstyled components. This change reworks that to let the build plugin handle the moduleHash and modifies the babel plugin to replace the imports to the `.css.js` file too.

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.10.1-canary.603.13514.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.10.1-canary.603.13514.0
  npm install @design-systems/babel-plugin-replace-styles@2.10.1-canary.603.13514.0
  npm install @design-systems/cli-utils@2.10.1-canary.603.13514.0
  npm install @design-systems/cli@2.10.1-canary.603.13514.0
  npm install @design-systems/core@2.10.1-canary.603.13514.0
  npm install @design-systems/create@2.10.1-canary.603.13514.0
  npm install @design-systems/docs@2.10.1-canary.603.13514.0
  npm install @design-systems/eslint-config@2.10.1-canary.603.13514.0
  npm install @design-systems/load-config@2.10.1-canary.603.13514.0
  npm install @design-systems/next-esm-css@2.10.1-canary.603.13514.0
  npm install @design-systems/plugin@2.10.1-canary.603.13514.0
  npm install @design-systems/stylelint-config@2.10.1-canary.603.13514.0
  npm install @design-systems/utils@2.10.1-canary.603.13514.0
  npm install @design-systems/build@2.10.1-canary.603.13514.0
  npm install @design-systems/bundle@2.10.1-canary.603.13514.0
  npm install @design-systems/clean@2.10.1-canary.603.13514.0
  npm install @design-systems/create-command@2.10.1-canary.603.13514.0
  npm install @design-systems/dev@2.10.1-canary.603.13514.0
  npm install @design-systems/lint@2.10.1-canary.603.13514.0
  npm install @design-systems/playroom@2.10.1-canary.603.13514.0
  npm install @design-systems/proof@2.10.1-canary.603.13514.0
  npm install @design-systems/size@2.10.1-canary.603.13514.0
  npm install @design-systems/storybook@2.10.1-canary.603.13514.0
  npm install @design-systems/test@2.10.1-canary.603.13514.0
  npm install @design-systems/update@2.10.1-canary.603.13514.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.10.1-canary.603.13514.0
  yarn add @design-systems/babel-plugin-replace-styles@2.10.1-canary.603.13514.0
  yarn add @design-systems/cli-utils@2.10.1-canary.603.13514.0
  yarn add @design-systems/cli@2.10.1-canary.603.13514.0
  yarn add @design-systems/core@2.10.1-canary.603.13514.0
  yarn add @design-systems/create@2.10.1-canary.603.13514.0
  yarn add @design-systems/docs@2.10.1-canary.603.13514.0
  yarn add @design-systems/eslint-config@2.10.1-canary.603.13514.0
  yarn add @design-systems/load-config@2.10.1-canary.603.13514.0
  yarn add @design-systems/next-esm-css@2.10.1-canary.603.13514.0
  yarn add @design-systems/plugin@2.10.1-canary.603.13514.0
  yarn add @design-systems/stylelint-config@2.10.1-canary.603.13514.0
  yarn add @design-systems/utils@2.10.1-canary.603.13514.0
  yarn add @design-systems/build@2.10.1-canary.603.13514.0
  yarn add @design-systems/bundle@2.10.1-canary.603.13514.0
  yarn add @design-systems/clean@2.10.1-canary.603.13514.0
  yarn add @design-systems/create-command@2.10.1-canary.603.13514.0
  yarn add @design-systems/dev@2.10.1-canary.603.13514.0
  yarn add @design-systems/lint@2.10.1-canary.603.13514.0
  yarn add @design-systems/playroom@2.10.1-canary.603.13514.0
  yarn add @design-systems/proof@2.10.1-canary.603.13514.0
  yarn add @design-systems/size@2.10.1-canary.603.13514.0
  yarn add @design-systems/storybook@2.10.1-canary.603.13514.0
  yarn add @design-systems/test@2.10.1-canary.603.13514.0
  yarn add @design-systems/update@2.10.1-canary.603.13514.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
