### PR TITLE
Enable json-summary coverage reporter

### DIFF
--- a/plugins/test/src/jest.config.base.ts
+++ b/plugins/test/src/jest.config.base.ts
@@ -19,7 +19,7 @@ module.exports = {
     '\\.(js|jsx|ts|tsx)$': path.join(__dirname, './jest/transform.js')
   },
   coverageDirectory: 'target/coverage',
-  coverageReporters: ['text', 'cobertura', 'html', 'lcov'],
+  coverageReporters: ['text', 'cobertura', 'html', 'lcov', 'json-summary'],
   collectCoverageFrom: [
     '**/src/**',
     '!**/*.json',


### PR DESCRIPTION
# What Changed
Enabled json-summary coverage reporter by default

# Why
Its cleaner to use JSON for analysis than the cobertura XML report

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.12.1-canary.619.14774.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.12.1-canary.619.14774.0
  npm install @design-systems/babel-plugin-replace-styles@2.12.1-canary.619.14774.0
  npm install @design-systems/cli-utils@2.12.1-canary.619.14774.0
  npm install @design-systems/cli@2.12.1-canary.619.14774.0
  npm install @design-systems/core@2.12.1-canary.619.14774.0
  npm install @design-systems/create@2.12.1-canary.619.14774.0
  npm install @design-systems/docs@2.12.1-canary.619.14774.0
  npm install @design-systems/eslint-config@2.12.1-canary.619.14774.0
  npm install @design-systems/load-config@2.12.1-canary.619.14774.0
  npm install @design-systems/next-esm-css@2.12.1-canary.619.14774.0
  npm install @design-systems/plugin@2.12.1-canary.619.14774.0
  npm install @design-systems/stylelint-config@2.12.1-canary.619.14774.0
  npm install @design-systems/svg-icon-builder@2.12.1-canary.619.14774.0
  npm install @design-systems/utils@2.12.1-canary.619.14774.0
  npm install @design-systems/build@2.12.1-canary.619.14774.0
  npm install @design-systems/bundle@2.12.1-canary.619.14774.0
  npm install @design-systems/clean@2.12.1-canary.619.14774.0
  npm install @design-systems/create-command@2.12.1-canary.619.14774.0
  npm install @design-systems/dev@2.12.1-canary.619.14774.0
  npm install @design-systems/lint@2.12.1-canary.619.14774.0
  npm install @design-systems/playroom@2.12.1-canary.619.14774.0
  npm install @design-systems/proof@2.12.1-canary.619.14774.0
  npm install @design-systems/size@2.12.1-canary.619.14774.0
  npm install @design-systems/storybook@2.12.1-canary.619.14774.0
  npm install @design-systems/test@2.12.1-canary.619.14774.0
  npm install @design-systems/update@2.12.1-canary.619.14774.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.12.1-canary.619.14774.0
  yarn add @design-systems/babel-plugin-replace-styles@2.12.1-canary.619.14774.0
  yarn add @design-systems/cli-utils@2.12.1-canary.619.14774.0
  yarn add @design-systems/cli@2.12.1-canary.619.14774.0
  yarn add @design-systems/core@2.12.1-canary.619.14774.0
  yarn add @design-systems/create@2.12.1-canary.619.14774.0
  yarn add @design-systems/docs@2.12.1-canary.619.14774.0
  yarn add @design-systems/eslint-config@2.12.1-canary.619.14774.0
  yarn add @design-systems/load-config@2.12.1-canary.619.14774.0
  yarn add @design-systems/next-esm-css@2.12.1-canary.619.14774.0
  yarn add @design-systems/plugin@2.12.1-canary.619.14774.0
  yarn add @design-systems/stylelint-config@2.12.1-canary.619.14774.0
  yarn add @design-systems/svg-icon-builder@2.12.1-canary.619.14774.0
  yarn add @design-systems/utils@2.12.1-canary.619.14774.0
  yarn add @design-systems/build@2.12.1-canary.619.14774.0
  yarn add @design-systems/bundle@2.12.1-canary.619.14774.0
  yarn add @design-systems/clean@2.12.1-canary.619.14774.0
  yarn add @design-systems/create-command@2.12.1-canary.619.14774.0
  yarn add @design-systems/dev@2.12.1-canary.619.14774.0
  yarn add @design-systems/lint@2.12.1-canary.619.14774.0
  yarn add @design-systems/playroom@2.12.1-canary.619.14774.0
  yarn add @design-systems/proof@2.12.1-canary.619.14774.0
  yarn add @design-systems/size@2.12.1-canary.619.14774.0
  yarn add @design-systems/storybook@2.12.1-canary.619.14774.0
  yarn add @design-systems/test@2.12.1-canary.619.14774.0
  yarn add @design-systems/update@2.12.1-canary.619.14774.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
