### PR TITLE
turn off jsdoc/no-types for jsx files

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -203,6 +203,7 @@ module.exports = {
     {
       files: ['*.{js,jsx}'],
       rules: {
+        'jsdoc/no-types': 0,
         '@typescript-eslint/no-var-requires': 'off',
       },
     },


### PR DESCRIPTION
# What Changed
- turn off eslint `jsdoc/no-types` for jsx files
# Why
- this rule has an autoformatter that deletes types from jsx files. this is no fun when trying to progressively add types to our mixed js/ts codebase. this fix should stop that behavior
Todo:
- [ ] verify that this works w/ canary build
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.12.2-canary.620.14790.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.12.2-canary.620.14790.0
  npm install @design-systems/babel-plugin-replace-styles@2.12.2-canary.620.14790.0
  npm install @design-systems/cli-utils@2.12.2-canary.620.14790.0
  npm install @design-systems/cli@2.12.2-canary.620.14790.0
  npm install @design-systems/core@2.12.2-canary.620.14790.0
  npm install @design-systems/create@2.12.2-canary.620.14790.0
  npm install @design-systems/docs@2.12.2-canary.620.14790.0
  npm install @design-systems/eslint-config@2.12.2-canary.620.14790.0
  npm install @design-systems/load-config@2.12.2-canary.620.14790.0
  npm install @design-systems/next-esm-css@2.12.2-canary.620.14790.0
  npm install @design-systems/plugin@2.12.2-canary.620.14790.0
  npm install @design-systems/stylelint-config@2.12.2-canary.620.14790.0
  npm install @design-systems/svg-icon-builder@2.12.2-canary.620.14790.0
  npm install @design-systems/utils@2.12.2-canary.620.14790.0
  npm install @design-systems/build@2.12.2-canary.620.14790.0
  npm install @design-systems/bundle@2.12.2-canary.620.14790.0
  npm install @design-systems/clean@2.12.2-canary.620.14790.0
  npm install @design-systems/create-command@2.12.2-canary.620.14790.0
  npm install @design-systems/dev@2.12.2-canary.620.14790.0
  npm install @design-systems/lint@2.12.2-canary.620.14790.0
  npm install @design-systems/playroom@2.12.2-canary.620.14790.0
  npm install @design-systems/proof@2.12.2-canary.620.14790.0
  npm install @design-systems/size@2.12.2-canary.620.14790.0
  npm install @design-systems/storybook@2.12.2-canary.620.14790.0
  npm install @design-systems/test@2.12.2-canary.620.14790.0
  npm install @design-systems/update@2.12.2-canary.620.14790.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.12.2-canary.620.14790.0
  yarn add @design-systems/babel-plugin-replace-styles@2.12.2-canary.620.14790.0
  yarn add @design-systems/cli-utils@2.12.2-canary.620.14790.0
  yarn add @design-systems/cli@2.12.2-canary.620.14790.0
  yarn add @design-systems/core@2.12.2-canary.620.14790.0
  yarn add @design-systems/create@2.12.2-canary.620.14790.0
  yarn add @design-systems/docs@2.12.2-canary.620.14790.0
  yarn add @design-systems/eslint-config@2.12.2-canary.620.14790.0
  yarn add @design-systems/load-config@2.12.2-canary.620.14790.0
  yarn add @design-systems/next-esm-css@2.12.2-canary.620.14790.0
  yarn add @design-systems/plugin@2.12.2-canary.620.14790.0
  yarn add @design-systems/stylelint-config@2.12.2-canary.620.14790.0
  yarn add @design-systems/svg-icon-builder@2.12.2-canary.620.14790.0
  yarn add @design-systems/utils@2.12.2-canary.620.14790.0
  yarn add @design-systems/build@2.12.2-canary.620.14790.0
  yarn add @design-systems/bundle@2.12.2-canary.620.14790.0
  yarn add @design-systems/clean@2.12.2-canary.620.14790.0
  yarn add @design-systems/create-command@2.12.2-canary.620.14790.0
  yarn add @design-systems/dev@2.12.2-canary.620.14790.0
  yarn add @design-systems/lint@2.12.2-canary.620.14790.0
  yarn add @design-systems/playroom@2.12.2-canary.620.14790.0
  yarn add @design-systems/proof@2.12.2-canary.620.14790.0
  yarn add @design-systems/size@2.12.2-canary.620.14790.0
  yarn add @design-systems/storybook@2.12.2-canary.620.14790.0
  yarn add @design-systems/test@2.12.2-canary.620.14790.0
  yarn add @design-systems/update@2.12.2-canary.620.14790.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
