### PR TITLE
use version in babel runtime for bundle size wins

### DIFF
--- a/plugins/build/src/configs/babel.config.ts
+++ b/plugins/build/src/configs/babel.config.ts
@@ -1,6 +1,6 @@
 import babel from '@babel/core';
 
-export default function(api: babel.ConfigAPI) {
+export default function (api: babel.ConfigAPI) {
   const isTest = api.env('test');
 
   return {
@@ -13,7 +13,7 @@ export default function(api: babel.ConfigAPI) {
       // This must come after env! otherwise interfaces might remain in the mjs files
       '@babel/preset-typescript',
       '@babel/preset-react',
-      isTest && 'jest'
+      isTest && 'jest',
     ].filter(Boolean),
     plugins: [
       '@babel/plugin-proposal-class-properties',
@@ -22,9 +22,10 @@ export default function(api: babel.ConfigAPI) {
       [
         '@babel/plugin-transform-runtime',
         {
-          regenerator: true
-        }
-      ]
-    ].filter(Boolean)
+          regenerator: true,
+          version: '7.11.2',
+        },
+      ],
+    ].filter(Boolean),
   };
 }


### PR DESCRIPTION
Without this babel includes some helpers multiple times
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.12.3-canary.633.15627.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.12.3-canary.633.15627.0
  npm install @design-systems/babel-plugin-replace-styles@2.12.3-canary.633.15627.0
  npm install @design-systems/cli-utils@2.12.3-canary.633.15627.0
  npm install @design-systems/cli@2.12.3-canary.633.15627.0
  npm install @design-systems/core@2.12.3-canary.633.15627.0
  npm install @design-systems/create@2.12.3-canary.633.15627.0
  npm install @design-systems/docs@2.12.3-canary.633.15627.0
  npm install @design-systems/eslint-config@2.12.3-canary.633.15627.0
  npm install @design-systems/load-config@2.12.3-canary.633.15627.0
  npm install @design-systems/next-esm-css@2.12.3-canary.633.15627.0
  npm install @design-systems/plugin@2.12.3-canary.633.15627.0
  npm install @design-systems/stylelint-config@2.12.3-canary.633.15627.0
  npm install @design-systems/svg-icon-builder@2.12.3-canary.633.15627.0
  npm install @design-systems/utils@2.12.3-canary.633.15627.0
  npm install @design-systems/build@2.12.3-canary.633.15627.0
  npm install @design-systems/bundle@2.12.3-canary.633.15627.0
  npm install @design-systems/clean@2.12.3-canary.633.15627.0
  npm install @design-systems/create-command@2.12.3-canary.633.15627.0
  npm install @design-systems/dev@2.12.3-canary.633.15627.0
  npm install @design-systems/lint@2.12.3-canary.633.15627.0
  npm install @design-systems/playroom@2.12.3-canary.633.15627.0
  npm install @design-systems/proof@2.12.3-canary.633.15627.0
  npm install @design-systems/size@2.12.3-canary.633.15627.0
  npm install @design-systems/storybook@2.12.3-canary.633.15627.0
  npm install @design-systems/test@2.12.3-canary.633.15627.0
  npm install @design-systems/update@2.12.3-canary.633.15627.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.12.3-canary.633.15627.0
  yarn add @design-systems/babel-plugin-replace-styles@2.12.3-canary.633.15627.0
  yarn add @design-systems/cli-utils@2.12.3-canary.633.15627.0
  yarn add @design-systems/cli@2.12.3-canary.633.15627.0
  yarn add @design-systems/core@2.12.3-canary.633.15627.0
  yarn add @design-systems/create@2.12.3-canary.633.15627.0
  yarn add @design-systems/docs@2.12.3-canary.633.15627.0
  yarn add @design-systems/eslint-config@2.12.3-canary.633.15627.0
  yarn add @design-systems/load-config@2.12.3-canary.633.15627.0
  yarn add @design-systems/next-esm-css@2.12.3-canary.633.15627.0
  yarn add @design-systems/plugin@2.12.3-canary.633.15627.0
  yarn add @design-systems/stylelint-config@2.12.3-canary.633.15627.0
  yarn add @design-systems/svg-icon-builder@2.12.3-canary.633.15627.0
  yarn add @design-systems/utils@2.12.3-canary.633.15627.0
  yarn add @design-systems/build@2.12.3-canary.633.15627.0
  yarn add @design-systems/bundle@2.12.3-canary.633.15627.0
  yarn add @design-systems/clean@2.12.3-canary.633.15627.0
  yarn add @design-systems/create-command@2.12.3-canary.633.15627.0
  yarn add @design-systems/dev@2.12.3-canary.633.15627.0
  yarn add @design-systems/lint@2.12.3-canary.633.15627.0
  yarn add @design-systems/playroom@2.12.3-canary.633.15627.0
  yarn add @design-systems/proof@2.12.3-canary.633.15627.0
  yarn add @design-systems/size@2.12.3-canary.633.15627.0
  yarn add @design-systems/storybook@2.12.3-canary.633.15627.0
  yarn add @design-systems/test@2.12.3-canary.633.15627.0
  yarn add @design-systems/update@2.12.3-canary.633.15627.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
