### PR TITLE
Persist size output

### DIFF
--- a/plugins/size/src/utils/CalcSizeUtils.ts
+++ b/plugins/size/src/utils/CalcSizeUtils.ts
@@ -303,7 +303,7 @@ async function calcSizeForAllPackages(args: SizeArgs) {
       const size = await diffSizeForPackage({
         name: packageJson.package.name,
         main: packagePath,
-        persist: undefined,
+        persist: args.persist,
         chunkByExport: args.detailed,
         registry: args.registry,
       });

--- a/plugins/size/src/utils/WebpackUtils.ts
+++ b/plugins/size/src/utils/WebpackUtils.ts
@@ -178,7 +178,7 @@ async function getSizes(options: GetSizesOptions & CommonOptions) {
       fs.copyFileSync(npmrc, path.join(dir, '.npmrc'));
     }
 
-    logger.info(`Installing: ${options.name}`);
+    logger.debug(`Installing: ${options.name}`);
     if (options.registry) {
       execSync(
         `yarn add ${options.name} --registry ${options.registry}`,

--- a/plugins/size/src/utils/WebpackUtils.ts
+++ b/plugins/size/src/utils/WebpackUtils.ts
@@ -178,7 +178,7 @@ async function getSizes(options: GetSizesOptions & CommonOptions) {
       fs.copyFileSync(npmrc, path.join(dir, '.npmrc'));
     }
 
-    logger.debug(`Installing: ${options.name}`);
+    logger.info(`Installing: ${options.name}`);
     if (options.registry) {
       execSync(
         `yarn add ${options.name} --registry ${options.registry}`,
@@ -201,7 +201,7 @@ async function getSizes(options: GetSizesOptions & CommonOptions) {
   );
   logger.debug(`Completed building: ${dir}`);
   if (options.persist) {
-    const folder = `bundle-${options.scope}`;
+    const folder = `bundle-${options.scope}-${options.importName}`;
     const out = path.join(process.cwd(), folder);
     logger.info(`Persisting output to: ${folder}`);
     await fs.remove(out);


### PR DESCRIPTION
# What Changed

Enable persist option for size calculation for all packages.

# Why

As a part of paved road initiative we need to extract the gzip size and parse size for all components.

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.14.1-canary.641.16436.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.14.1-canary.641.16436.0
  npm install @design-systems/babel-plugin-replace-styles@2.14.1-canary.641.16436.0
  npm install @design-systems/cli-utils@2.14.1-canary.641.16436.0
  npm install @design-systems/cli@2.14.1-canary.641.16436.0
  npm install @design-systems/core@2.14.1-canary.641.16436.0
  npm install @design-systems/create@2.14.1-canary.641.16436.0
  npm install @design-systems/docs@2.14.1-canary.641.16436.0
  npm install @design-systems/eslint-config@2.14.1-canary.641.16436.0
  npm install @design-systems/load-config@2.14.1-canary.641.16436.0
  npm install @design-systems/next-esm-css@2.14.1-canary.641.16436.0
  npm install @design-systems/plugin@2.14.1-canary.641.16436.0
  npm install @design-systems/stylelint-config@2.14.1-canary.641.16436.0
  npm install @design-systems/svg-icon-builder@2.14.1-canary.641.16436.0
  npm install @design-systems/utils@2.14.1-canary.641.16436.0
  npm install @design-systems/build@2.14.1-canary.641.16436.0
  npm install @design-systems/bundle@2.14.1-canary.641.16436.0
  npm install @design-systems/clean@2.14.1-canary.641.16436.0
  npm install @design-systems/create-command@2.14.1-canary.641.16436.0
  npm install @design-systems/dev@2.14.1-canary.641.16436.0
  npm install @design-systems/lint@2.14.1-canary.641.16436.0
  npm install @design-systems/playroom@2.14.1-canary.641.16436.0
  npm install @design-systems/proof@2.14.1-canary.641.16436.0
  npm install @design-systems/size@2.14.1-canary.641.16436.0
  npm install @design-systems/storybook@2.14.1-canary.641.16436.0
  npm install @design-systems/test@2.14.1-canary.641.16436.0
  npm install @design-systems/update@2.14.1-canary.641.16436.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.14.1-canary.641.16436.0
  yarn add @design-systems/babel-plugin-replace-styles@2.14.1-canary.641.16436.0
  yarn add @design-systems/cli-utils@2.14.1-canary.641.16436.0
  yarn add @design-systems/cli@2.14.1-canary.641.16436.0
  yarn add @design-systems/core@2.14.1-canary.641.16436.0
  yarn add @design-systems/create@2.14.1-canary.641.16436.0
  yarn add @design-systems/docs@2.14.1-canary.641.16436.0
  yarn add @design-systems/eslint-config@2.14.1-canary.641.16436.0
  yarn add @design-systems/load-config@2.14.1-canary.641.16436.0
  yarn add @design-systems/next-esm-css@2.14.1-canary.641.16436.0
  yarn add @design-systems/plugin@2.14.1-canary.641.16436.0
  yarn add @design-systems/stylelint-config@2.14.1-canary.641.16436.0
  yarn add @design-systems/svg-icon-builder@2.14.1-canary.641.16436.0
  yarn add @design-systems/utils@2.14.1-canary.641.16436.0
  yarn add @design-systems/build@2.14.1-canary.641.16436.0
  yarn add @design-systems/bundle@2.14.1-canary.641.16436.0
  yarn add @design-systems/clean@2.14.1-canary.641.16436.0
  yarn add @design-systems/create-command@2.14.1-canary.641.16436.0
  yarn add @design-systems/dev@2.14.1-canary.641.16436.0
  yarn add @design-systems/lint@2.14.1-canary.641.16436.0
  yarn add @design-systems/playroom@2.14.1-canary.641.16436.0
  yarn add @design-systems/proof@2.14.1-canary.641.16436.0
  yarn add @design-systems/size@2.14.1-canary.641.16436.0
  yarn add @design-systems/storybook@2.14.1-canary.641.16436.0
  yarn add @design-systems/test@2.14.1-canary.641.16436.0
  yarn add @design-systems/update@2.14.1-canary.641.16436.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
