### PR TITLE
Fix multiple identical typos

### DIFF
--- a/packages/docs/src/advanced/annotate.md
+++ b/packages/docs/src/advanced/annotate.md
@@ -1,13 +1,13 @@
 # GitHub Annotations
 
-`@design-systems` CLI ship with the ability to create [GitHub Checks](https://developer.github.com/v3/checks/) and annoations for some of it's commands.
+`@design-systems` CLI ship with the ability to create [GitHub Checks](https://developer.github.com/v3/checks/) and annotations for some of it's commands.
 
-Commands with annoations support:
+Commands with annotations support:
 
 - `lint` - Add annotations in JS/TS and CSS for errors and warnings
 - `test` - Add annotations in test files for failed tests
 
-Just use the `--annotate` flag and install the GitHub apps then the commands should create annoations when run in a CI environment.
+Just use the `--annotate` flag and install the GitHub apps then the commands should create annotations when run in a CI environment.
 
 Apps to install:
 
@@ -17,7 +17,7 @@ Apps to install:
 
 ## Customize GitHub App
 
-You can customize the GitHub app that is used to create the annoations. This step is necassary to support GitHub enterprise instances.
+You can customize the GitHub app that is used to create the annotations. This step is necassary to support GitHub enterprise instances.
 
 Either set environment variables for each tool:
 
@@ -28,9 +28,9 @@ Either set environment variables for each tool:
 - `STYLELINT_APP_ID`
 - `STYLELINT_PRIVATE_KEY`
 
-Or if you want just 1 GitHub app to manage the annoations:
+Or if you want just 1 GitHub app to manage the annotations:
 
 - `CLI_APP_ID`
 - `CLI_PRIVATE_KEY`
 
-If given `CLI_APP_ID` and `CLI_PRIVATE_KEY` it is assumed that you want annoations so you do not need to use the `--annoation` flag.
+If given `CLI_APP_ID` and `CLI_PRIVATE_KEY` it is assumed that you want annotations so you do not need to use the `--annoation` flag.


### PR DESCRIPTION
I guess there was some copy/pasting or global search/replace here, with `annoations` present multiple times.

Also, I'm not sure about the `--annoation` flag at the end. Should it be `--annotation` with the missing `t`, or `--annotate`?

# What Changed

Just little documentation fixes.

# Why

Typos.

Todo:

- [ ] Add tests
- [x] Add docs
