### PR TITLE
fix: enabling FAILURE_THRESHOLD to be read from cmdArgs

### DIFF
--- a/plugins/size/src/utils/CalcSizeUtils.ts
+++ b/plugins/size/src/utils/CalcSizeUtils.ts
@@ -20,7 +20,6 @@ import {
 } from '../interfaces';
 import { getSizes } from './WebpackUtils';
 
-const FAILURE_THRESHOLD = 5;
 const RUNTIME_SIZE = 537;
 
 export const logger = createLogger({ scope: 'size' });
@@ -309,6 +308,7 @@ async function calcSizeForAllPackages(args: SizeArgs) {
       });
       results.push(size);
 
+      const FAILURE_THRESHOLD = args.failureThreshold || 5;
       if (size.percent > FAILURE_THRESHOLD && size.percent !== Infinity) {
         success = false;
         logger.error(`${packageJson.package.name} failed bundle size check :(`);


### PR DESCRIPTION
# What Changed
enabling FAILURE_THRESHOLD to be read from cmdArgs

# Why
It was missed in the utils and the threshold always defaulted to 5

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.17.2--canary.649.17093.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.17.2--canary.649.17093.0
  npm install @design-systems/babel-plugin-replace-styles@2.17.2--canary.649.17093.0
  npm install @design-systems/cli-utils@2.17.2--canary.649.17093.0
  npm install @design-systems/cli@2.17.2--canary.649.17093.0
  npm install @design-systems/core@2.17.2--canary.649.17093.0
  npm install @design-systems/create@2.17.2--canary.649.17093.0
  npm install @design-systems/docs@2.17.2--canary.649.17093.0
  npm install @design-systems/eslint-config@2.17.2--canary.649.17093.0
  npm install @design-systems/load-config@2.17.2--canary.649.17093.0
  npm install @design-systems/next-esm-css@2.17.2--canary.649.17093.0
  npm install @design-systems/plugin@2.17.2--canary.649.17093.0
  npm install @design-systems/stylelint-config@2.17.2--canary.649.17093.0
  npm install @design-systems/svg-icon-builder@2.17.2--canary.649.17093.0
  npm install @design-systems/utils@2.17.2--canary.649.17093.0
  npm install @design-systems/build@2.17.2--canary.649.17093.0
  npm install @design-systems/bundle@2.17.2--canary.649.17093.0
  npm install @design-systems/clean@2.17.2--canary.649.17093.0
  npm install @design-systems/create-command@2.17.2--canary.649.17093.0
  npm install @design-systems/dev@2.17.2--canary.649.17093.0
  npm install @design-systems/lint@2.17.2--canary.649.17093.0
  npm install @design-systems/playroom@2.17.2--canary.649.17093.0
  npm install @design-systems/proof@2.17.2--canary.649.17093.0
  npm install @design-systems/size@2.17.2--canary.649.17093.0
  npm install @design-systems/storybook@2.17.2--canary.649.17093.0
  npm install @design-systems/test@2.17.2--canary.649.17093.0
  npm install @design-systems/update@2.17.2--canary.649.17093.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.17.2--canary.649.17093.0
  yarn add @design-systems/babel-plugin-replace-styles@2.17.2--canary.649.17093.0
  yarn add @design-systems/cli-utils@2.17.2--canary.649.17093.0
  yarn add @design-systems/cli@2.17.2--canary.649.17093.0
  yarn add @design-systems/core@2.17.2--canary.649.17093.0
  yarn add @design-systems/create@2.17.2--canary.649.17093.0
  yarn add @design-systems/docs@2.17.2--canary.649.17093.0
  yarn add @design-systems/eslint-config@2.17.2--canary.649.17093.0
  yarn add @design-systems/load-config@2.17.2--canary.649.17093.0
  yarn add @design-systems/next-esm-css@2.17.2--canary.649.17093.0
  yarn add @design-systems/plugin@2.17.2--canary.649.17093.0
  yarn add @design-systems/stylelint-config@2.17.2--canary.649.17093.0
  yarn add @design-systems/svg-icon-builder@2.17.2--canary.649.17093.0
  yarn add @design-systems/utils@2.17.2--canary.649.17093.0
  yarn add @design-systems/build@2.17.2--canary.649.17093.0
  yarn add @design-systems/bundle@2.17.2--canary.649.17093.0
  yarn add @design-systems/clean@2.17.2--canary.649.17093.0
  yarn add @design-systems/create-command@2.17.2--canary.649.17093.0
  yarn add @design-systems/dev@2.17.2--canary.649.17093.0
  yarn add @design-systems/lint@2.17.2--canary.649.17093.0
  yarn add @design-systems/playroom@2.17.2--canary.649.17093.0
  yarn add @design-systems/proof@2.17.2--canary.649.17093.0
  yarn add @design-systems/size@2.17.2--canary.649.17093.0
  yarn add @design-systems/storybook@2.17.2--canary.649.17093.0
  yarn add @design-systems/test@2.17.2--canary.649.17093.0
  yarn add @design-systems/update@2.17.2--canary.649.17093.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
