### PR TITLE
Use resolved location for source-map-loader

### DIFF
--- a/plugins/storybook/.storybook/modify-webpack.js
+++ b/plugins/storybook/.storybook/modify-webpack.js
@@ -131,7 +131,7 @@ function addSourceMaps(config) {
     test: /\.(js|css)$/,
     exclude: /node_modules/,
     include: new RegExp(monorepoName()),
-    use: ['source-map-loader'],
+    use: [require.resolve('source-map-loader')],
     enforce: 'pre'
   });
 }


### PR DESCRIPTION
# What Changed

Adds resolved location for `source-map-loader` dep in webpack config. Since the webpack process may not run in the same tree -- resolving it relative to the storybook plugin should pull in the correct location. 

# Why

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.17.4--canary.654.17576.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@2.17.4--canary.654.17576.0
  npm install @design-systems/babel-plugin-replace-styles@2.17.4--canary.654.17576.0
  npm install @design-systems/cli-utils@2.17.4--canary.654.17576.0
  npm install @design-systems/cli@2.17.4--canary.654.17576.0
  npm install @design-systems/core@2.17.4--canary.654.17576.0
  npm install @design-systems/create@2.17.4--canary.654.17576.0
  npm install @design-systems/docs@2.17.4--canary.654.17576.0
  npm install @design-systems/eslint-config@2.17.4--canary.654.17576.0
  npm install @design-systems/load-config@2.17.4--canary.654.17576.0
  npm install @design-systems/next-esm-css@2.17.4--canary.654.17576.0
  npm install @design-systems/plugin@2.17.4--canary.654.17576.0
  npm install @design-systems/stylelint-config@2.17.4--canary.654.17576.0
  npm install @design-systems/svg-icon-builder@2.17.4--canary.654.17576.0
  npm install @design-systems/utils@2.17.4--canary.654.17576.0
  npm install @design-systems/build@2.17.4--canary.654.17576.0
  npm install @design-systems/bundle@2.17.4--canary.654.17576.0
  npm install @design-systems/clean@2.17.4--canary.654.17576.0
  npm install @design-systems/create-command@2.17.4--canary.654.17576.0
  npm install @design-systems/dev@2.17.4--canary.654.17576.0
  npm install @design-systems/lint@2.17.4--canary.654.17576.0
  npm install @design-systems/playroom@2.17.4--canary.654.17576.0
  npm install @design-systems/proof@2.17.4--canary.654.17576.0
  npm install @design-systems/size@2.17.4--canary.654.17576.0
  npm install @design-systems/storybook@2.17.4--canary.654.17576.0
  npm install @design-systems/test@2.17.4--canary.654.17576.0
  npm install @design-systems/update@2.17.4--canary.654.17576.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@2.17.4--canary.654.17576.0
  yarn add @design-systems/babel-plugin-replace-styles@2.17.4--canary.654.17576.0
  yarn add @design-systems/cli-utils@2.17.4--canary.654.17576.0
  yarn add @design-systems/cli@2.17.4--canary.654.17576.0
  yarn add @design-systems/core@2.17.4--canary.654.17576.0
  yarn add @design-systems/create@2.17.4--canary.654.17576.0
  yarn add @design-systems/docs@2.17.4--canary.654.17576.0
  yarn add @design-systems/eslint-config@2.17.4--canary.654.17576.0
  yarn add @design-systems/load-config@2.17.4--canary.654.17576.0
  yarn add @design-systems/next-esm-css@2.17.4--canary.654.17576.0
  yarn add @design-systems/plugin@2.17.4--canary.654.17576.0
  yarn add @design-systems/stylelint-config@2.17.4--canary.654.17576.0
  yarn add @design-systems/svg-icon-builder@2.17.4--canary.654.17576.0
  yarn add @design-systems/utils@2.17.4--canary.654.17576.0
  yarn add @design-systems/build@2.17.4--canary.654.17576.0
  yarn add @design-systems/bundle@2.17.4--canary.654.17576.0
  yarn add @design-systems/clean@2.17.4--canary.654.17576.0
  yarn add @design-systems/create-command@2.17.4--canary.654.17576.0
  yarn add @design-systems/dev@2.17.4--canary.654.17576.0
  yarn add @design-systems/lint@2.17.4--canary.654.17576.0
  yarn add @design-systems/playroom@2.17.4--canary.654.17576.0
  yarn add @design-systems/proof@2.17.4--canary.654.17576.0
  yarn add @design-systems/size@2.17.4--canary.654.17576.0
  yarn add @design-systems/storybook@2.17.4--canary.654.17576.0
  yarn add @design-systems/test@2.17.4--canary.654.17576.0
  yarn add @design-systems/update@2.17.4--canary.654.17576.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
