### PR TITLE
fallback to cwd when running outside of cli

### DIFF
--- a/plugins/storybook/.storybook/preset.js
+++ b/plugins/storybook/.storybook/preset.js
@@ -19,7 +19,10 @@ const addons = [
 ];
 
 const stories = glob.sync(
-  path.join(process.env.COMPONENT, '**/*.stories.(tsx|js|jsx|mdx)'),
+  path.join(
+    process.env.COMPONENT || process.cwd(),
+    '**/*.stories.(tsx|js|jsx|mdx)'
+  ),
   { ignore: ['**/node_modules'] }
 );
 


### PR DESCRIPTION
# What Changed

Fallback to `process.cwd()` when `process.env.COMPONENT` is not defined by webpack (when running outside of the ds-cli).

# Why

When debugging issues like the babel configuration problems, leveraging the default `start-storybook` helps quickly see the final configuration via `--debug-webpack`, but it quickly fails since `COMPONENT` is declared inside the ds-cli environment only.
