### PR TITLE
Implement --merge-base option in size plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,8 @@ jspm_packages/
 # next.js build output
 .next
 
+# VSCode workspace settings
+.vscode
+
 dist
 .DS_Store

--- a/plugins/size/src/command.ts
+++ b/plugins/size/src/command.ts
@@ -18,6 +18,10 @@ const command: CliCommand = {
     {
       example: 'ds size --ignore @foo/bar @foo/baz',
       desc: 'Ignore the sizes of packages @foo/bar and @foo/baz'
+    },
+    {
+      example: 'ds size --merge-base prerelease',
+      desc: 'Show the size changes between current HEAD and prerelease branch'
     }
   ],
   options: [
@@ -84,7 +88,12 @@ const command: CliCommand = {
       type: Number,
       description: 'Failure Threshold for Size',
       config: true
-    }    
+    },
+    {
+      name: 'merge-base',
+      type: String,
+      description: 'Run the plugin against merge base. (Will be slower due to additional build process)'
+    },
   ]
 };
 

--- a/plugins/size/src/command.ts
+++ b/plugins/size/src/command.ts
@@ -94,6 +94,12 @@ const command: CliCommand = {
       type: String,
       description: 'Run the plugin against merge base. (Will be slower due to additional build process)'
     },
+    {
+      name: 'build-command',
+      type: String,
+      description: 'Build command for --merge-base (defaults to "yarn build")',
+      defaultValue: 'yarn build'
+    }
   ]
 };
 

--- a/plugins/size/src/index.ts
+++ b/plugins/size/src/index.ts
@@ -7,6 +7,7 @@ import {
   SizeArgs,
   SizeResult} from "./interfaces"
 import { formatLine, formatExports } from "./utils/formatUtils";
+import { buildPackages } from "./utils/BuildUtils";
 import { calcSizeForAllPackages, reportResults, table, diffSizeForPackage } from "./utils/CalcSizeUtils";
 import { startAnalyze } from "./utils/WebpackUtils";
 import { createDiff } from "./utils/DiffUtils";
@@ -37,8 +38,20 @@ export default class SizePlugin implements Plugin<SizeArgs> {
       logger.disable();
     }
 
+    if (Object.prototype.hasOwnProperty.call(args, 'mergeBase') && !args.mergeBase) {
+      throw new Error('You must specify a commit-ish when --merge-base is set')
+    }
+
+    let local;
     if (fs.existsSync('lerna.json')) {
-      calcSizeForAllPackages(args);
+      if (args.mergeBase) {
+        local = buildPackages({ mergeBase: args.mergeBase });
+      }
+
+      calcSizeForAllPackages({
+        ...args,
+        local
+      });
       return;
     }
 
@@ -48,8 +61,12 @@ export default class SizePlugin implements Plugin<SizeArgs> {
       throw new Error('Could not find "process.env.npm_package_name"');
     }
 
+    if (args.mergeBase) {
+      local = buildPackages({ mergeBase: args.mergeBase, name });
+    }
+
     if (args.analyze) {
-      await startAnalyze(name, args.registry);
+      await startAnalyze(name, args.registry, local);
       return;
     }
 
@@ -65,7 +82,8 @@ export default class SizePlugin implements Plugin<SizeArgs> {
       persist: args.persist || args.diff,
       chunkByExport: args.detailed,
       diff: args.diff,
-      registry: args.registry
+      registry: args.registry,
+      local
     });
     const header = args.css ? cssHeader : defaultHeader;
 

--- a/plugins/size/src/index.ts
+++ b/plugins/size/src/index.ts
@@ -45,7 +45,7 @@ export default class SizePlugin implements Plugin<SizeArgs> {
     let local;
     if (fs.existsSync('lerna.json')) {
       if (args.mergeBase) {
-        local = buildPackages({ mergeBase: args.mergeBase });
+        local = buildPackages({ mergeBase: args.mergeBase, buildCommand: args.buildCommand });
       }
 
       calcSizeForAllPackages({
@@ -62,7 +62,7 @@ export default class SizePlugin implements Plugin<SizeArgs> {
     }
 
     if (args.mergeBase) {
-      local = buildPackages({ mergeBase: args.mergeBase, name });
+      local = buildPackages({ mergeBase: args.mergeBase, buildCommand: args.buildCommand });
     }
 
     if (args.analyze) {

--- a/plugins/size/src/interfaces.ts
+++ b/plugins/size/src/interfaces.ts
@@ -23,6 +23,8 @@ export interface SizeArgs {
   failureThreshold?: number
   /** Run the plugin against merge base. (Will be slower due to additional build process) */
   mergeBase?: string
+  /** Build command for merge base */
+  buildCommand: string
 }
 
 export interface Export {

--- a/plugins/size/src/interfaces.ts
+++ b/plugins/size/src/interfaces.ts
@@ -21,6 +21,8 @@ export interface SizeArgs {
   registry?: string
   /** Size Failure Threshold */
   failureThreshold?: number
+  /** Run the plugin against merge base. (Will be slower due to additional build process) */
+  mergeBase?: string
 }
 
 export interface Export {
@@ -70,9 +72,16 @@ export interface CommonOptions {
   diff?: boolean
   /** The registry to install packages from */
   registry?: string
+  /** Run the plugin against merge base. (Will be slower due to additional build process) */
+  mergeBase?: string
 }
 
-export interface GetSizesOptions {
+export interface CommonCalcSizeOptions {
+  /** Path to the local built master package */
+  local?: string
+}
+
+export interface GetSizesOptions extends CommonCalcSizeOptions {
   /** Whether to start the analyzer */
   analyze?: boolean
   /** What port to start the analyzer on */
@@ -81,9 +90,9 @@ export interface GetSizesOptions {
 
 type Scope = 'pr' | 'master'
 
-export interface DiffSizeForPackageOptions
-  extends Omit<CommonOptions, 'importName' | 'scope'> {
-  /** Path to the local built pacakge */
+export interface DiffSizeForPackageOptions extends CommonCalcSizeOptions,
+  Omit<CommonOptions, 'importName' | 'scope'> {
+  /** Path to the local built pr package */
   main: string
 }
 

--- a/plugins/size/src/utils/BuildUtils.ts
+++ b/plugins/size/src/utils/BuildUtils.ts
@@ -1,0 +1,64 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getMonorepoRoot, createLogger } from '@design-systems/cli-utils';
+
+const logger = createLogger({ scope: 'size' });
+
+/** Runs ds build against specified commit */
+export function buildPackages(args: {
+  /** Merge base to run build */
+  mergeBase: string
+  /** Package name to build. Defaults to monorepo root */
+  name?: string
+}) {
+  const id = Math.random().toString(36).substring(7);
+  const dir = path.join(os.tmpdir(), `commit-build-${id}`);
+  const root = getMonorepoRoot();
+
+  const commit = execSync(`git merge-base HEAD ${args.mergeBase}`, { cwd: root }).toString().trim();
+  execSync(`git clone . ${dir}`, { cwd: root, stdio: 'ignore' });
+  execSync(`git checkout ${commit}`, { cwd: dir, stdio: 'ignore' });
+
+  logger.info(`Installing dependencies for commit: ${commit} ...`);
+  execSync('yarn', { cwd: dir });
+
+  const pkgDir = args.name ? getLocalPackage(args.name, dir) : dir;
+  if (!fs.existsSync(pkgDir)) {
+    logger.info(`Package ${args.name} doesn't exist in commit ${commit}`)
+    logger.info('Skipping build.')
+    return dir;
+  }
+
+  logger.info(`Running yarn build for commit: ${commit} ...`);
+  execSync('yarn build', {
+    cwd: pkgDir,
+    stdio: 'inherit'
+  });
+
+  return dir;
+}
+
+/** Get locally built package path */
+export function getLocalPackage(
+  /** Locally built package name */
+  name: string,
+  /** Locally built monorepo root */
+  local: string
+) {
+  const packages = execSync(`lerna list --ndjson`)
+    .toString()
+    .trim()
+    .split('\n');
+
+  const pkg = packages
+    .map((p: string) => JSON.parse(p))
+    .find((p) => p.name === name);
+
+  if (!pkg) {
+    throw new Error(`Package not found: ${name}`);
+  }
+
+  return path.join(local, path.relative(getMonorepoRoot(), pkg.location));
+}

--- a/plugins/size/src/utils/BuildUtils.ts
+++ b/plugins/size/src/utils/BuildUtils.ts
@@ -6,7 +6,7 @@ import { getMonorepoRoot, createLogger } from '@design-systems/cli-utils';
 
 const logger = createLogger({ scope: 'size' });
 
-/** Runs ds build against specified commit */
+/** Builds the specified commit */
 export function buildPackages(args: {
   /** Merge base to run build */
   mergeBase: string
@@ -40,11 +40,11 @@ export function buildPackages(args: {
   return dir;
 }
 
-/** Get locally built package path */
+/** Get path to local built master package */
 export function getLocalPackage(
-  /** Locally built package name */
+  /** Package name */
   name: string,
-  /** Locally built monorepo root */
+  /** Path to local built master */
   local: string
 ) {
   const packages = execSync(`lerna list --ndjson`)

--- a/plugins/size/src/utils/BuildUtils.ts
+++ b/plugins/size/src/utils/BuildUtils.ts
@@ -1,5 +1,4 @@
 import { execSync } from 'child_process';
-import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { getMonorepoRoot, createLogger } from '@design-systems/cli-utils';
@@ -10,8 +9,8 @@ const logger = createLogger({ scope: 'size' });
 export function buildPackages(args: {
   /** Merge base to run build */
   mergeBase: string
-  /** Package name to build. Defaults to monorepo root */
-  name?: string
+  /** Build command for merge base */
+  buildCommand: string
 }) {
   const id = Math.random().toString(36).substring(7);
   const dir = path.join(os.tmpdir(), `commit-build-${id}`);
@@ -24,16 +23,9 @@ export function buildPackages(args: {
   logger.info(`Installing dependencies for commit: ${commit} ...`);
   execSync('yarn', { cwd: dir });
 
-  const pkgDir = args.name ? getLocalPackage(args.name, dir) : dir;
-  if (!fs.existsSync(pkgDir)) {
-    logger.info(`Package ${args.name} doesn't exist in commit ${commit}`)
-    logger.info('Skipping build.')
-    return dir;
-  }
-
-  logger.info(`Running yarn build for commit: ${commit} ...`);
-  execSync('yarn build', {
-    cwd: pkgDir,
+  logger.info(`Running command "${args.buildCommand}" for commit: ${commit} ...`);
+  execSync(args.buildCommand, {
+    cwd: dir,
     stdio: 'inherit'
   });
 

--- a/plugins/size/src/utils/WebpackUtils.ts
+++ b/plugins/size/src/utils/WebpackUtils.ts
@@ -15,6 +15,7 @@ import RelativeCommentsPlugin from '../RelativeCommentsPlugin';
 import { fromEntries } from './formatUtils';
 import { ConfigOptions, GetSizesOptions, CommonOptions } from '../interfaces';
 import { mockPackage } from './CalcSizeUtils';
+import { getLocalPackage } from './BuildUtils';
 
 const logger = createLogger({ scope: 'size' });
 
@@ -231,11 +232,11 @@ async function getSizes(options: GetSizesOptions & CommonOptions) {
 }
 
 /** Start the webpack bundle analyzer for both of the bundles. */
-async function startAnalyze(name: string, registry?: string) {
+async function startAnalyze(name: string, registry?: string, local?: string) {
   logger.start('Analyzing build output...');
   await Promise.all([
     getSizes({
-      name,
+      name: local ? getLocalPackage(name, local) : name,
       importName: name,
       scope: 'master',
       analyze: true,


### PR DESCRIPTION
# What Changed
This PR adds `--merge-base` option to `size` plugin that enables size comparison against merge base. Currently, `size` plugin performs diff against latest release tag as you can see in [WebpackUtils.ts#L188](https://github.com/intuit/design-systems-cli/blob/fc67966cb9657adab35abff1ba18b13ba516f2e4/plugins/size/src/utils/WebpackUtils.ts#L188). This is not always useful as you will see below.

# Why
The diagram below shows two simple cases where the current algorithm does and does not work. The orange dotted line shows two commits getting compared when you run `ds size`

<img src="https://user-images.githubusercontent.com/9959271/129326133-ebb65a90-a946-4523-9e60-37fd0dd3ce02.png" width="480">

In case 1, `pr` branch adds some changes to the master and runs `ds size`. The bundle report shows the correct result as expected.

In case 2, while one developer is working in `pr-2` branch, someone else made big changes in `pr-1` and released the package. When `pr-2` opens a PR to run the size report, it shows some huge numbers like +40% and -15% even if only one line of code is added. The size report is more useful if it only concerns changes in the current working tree.

IRL the situation tends to me more complex like having a prerelease/development branch and dozens of PRs getting merged every week. As such, we often see confusing numbers being reported in CI.

### After fix
<img src="https://user-images.githubusercontent.com/9959271/129333508-025a7daa-fe19-4ed2-b5e2-6474372cbaf8.png" width="400">

With `--merge-base <branch>` enabled, theoretically we can run `ds size` between any commits (i.e. circles in the diagram) and the report will generate correct size diff concerning that particular working tree. There are cases where this doesn't hold water, specifically when there are multiple [interesting commits](https://devblogs.microsoft.com/devops/supercharging-the-git-commit-graph-iii-generations/#using-generation-number-in-merge-base-questions), however, (1) this is an edge case and (2) merge base diff is still more meaningful than latest release diff.

Note that `--merge-base` option is slower due to additional `yarn install` and `yarn build`. I mentioned this in `command.ts` in attempt to warn users.

**Edit**: Also added `--build-command` option since different design-systems may have different build commands. Defaults to `yarn build`

Todo:

- [ ] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.12.1--canary.666.18313.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@4.12.1--canary.666.18313.0
  npm install @design-systems/babel-plugin-replace-styles@4.12.1--canary.666.18313.0
  npm install @design-systems/cli-utils@4.12.1--canary.666.18313.0
  npm install @design-systems/cli@4.12.1--canary.666.18313.0
  npm install @design-systems/core@4.12.1--canary.666.18313.0
  npm install @design-systems/create@4.12.1--canary.666.18313.0
  npm install @design-systems/docs@4.12.1--canary.666.18313.0
  npm install @design-systems/eslint-config@4.12.1--canary.666.18313.0
  npm install @design-systems/hooks@4.12.1--canary.666.18313.0
  npm install @design-systems/load-config@4.12.1--canary.666.18313.0
  npm install @design-systems/next-esm-css@4.12.1--canary.666.18313.0
  npm install @design-systems/plugin@4.12.1--canary.666.18313.0
  npm install @design-systems/stylelint-config@4.12.1--canary.666.18313.0
  npm install @design-systems/svg-icon-builder@4.12.1--canary.666.18313.0
  npm install @design-systems/utils@4.12.1--canary.666.18313.0
  npm install @design-systems/build@4.12.1--canary.666.18313.0
  npm install @design-systems/bundle@4.12.1--canary.666.18313.0
  npm install @design-systems/clean@4.12.1--canary.666.18313.0
  npm install @design-systems/create-command@4.12.1--canary.666.18313.0
  npm install @design-systems/dev@4.12.1--canary.666.18313.0
  npm install @design-systems/lint@4.12.1--canary.666.18313.0
  npm install @design-systems/playroom@4.12.1--canary.666.18313.0
  npm install @design-systems/proof@4.12.1--canary.666.18313.0
  npm install @design-systems/size@4.12.1--canary.666.18313.0
  npm install @design-systems/storybook@4.12.1--canary.666.18313.0
  npm install @design-systems/test@4.12.1--canary.666.18313.0
  npm install @design-systems/update@4.12.1--canary.666.18313.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@4.12.1--canary.666.18313.0
  yarn add @design-systems/babel-plugin-replace-styles@4.12.1--canary.666.18313.0
  yarn add @design-systems/cli-utils@4.12.1--canary.666.18313.0
  yarn add @design-systems/cli@4.12.1--canary.666.18313.0
  yarn add @design-systems/core@4.12.1--canary.666.18313.0
  yarn add @design-systems/create@4.12.1--canary.666.18313.0
  yarn add @design-systems/docs@4.12.1--canary.666.18313.0
  yarn add @design-systems/eslint-config@4.12.1--canary.666.18313.0
  yarn add @design-systems/hooks@4.12.1--canary.666.18313.0
  yarn add @design-systems/load-config@4.12.1--canary.666.18313.0
  yarn add @design-systems/next-esm-css@4.12.1--canary.666.18313.0
  yarn add @design-systems/plugin@4.12.1--canary.666.18313.0
  yarn add @design-systems/stylelint-config@4.12.1--canary.666.18313.0
  yarn add @design-systems/svg-icon-builder@4.12.1--canary.666.18313.0
  yarn add @design-systems/utils@4.12.1--canary.666.18313.0
  yarn add @design-systems/build@4.12.1--canary.666.18313.0
  yarn add @design-systems/bundle@4.12.1--canary.666.18313.0
  yarn add @design-systems/clean@4.12.1--canary.666.18313.0
  yarn add @design-systems/create-command@4.12.1--canary.666.18313.0
  yarn add @design-systems/dev@4.12.1--canary.666.18313.0
  yarn add @design-systems/lint@4.12.1--canary.666.18313.0
  yarn add @design-systems/playroom@4.12.1--canary.666.18313.0
  yarn add @design-systems/proof@4.12.1--canary.666.18313.0
  yarn add @design-systems/size@4.12.1--canary.666.18313.0
  yarn add @design-systems/storybook@4.12.1--canary.666.18313.0
  yarn add @design-systems/test@4.12.1--canary.666.18313.0
  yarn add @design-systems/update@4.12.1--canary.666.18313.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
