### PR TITLE
Size limit support

### DIFF
--- a/packages/docs/generate-docs.js
+++ b/packages/docs/generate-docs.js
@@ -46,11 +46,16 @@ const makeType = ({ type, typeName, multiple }) => {
   return multiple ? `${typeString}[]` : typeString;
 };
 
+/** Determine supported scope for option */
+const makeScope = ({ scope }) => {
+  return scope || 'Global'
+}
+
 /** Generate a table for an array of options */
 function generateOptionTable(options) {
   let text = dedent`\n
-    | Name | Type | Description |
-    | ---- | ---- | ----------- |
+    | Name | Type | Scope | Description |
+    | ---- | ---- | ----- | ----------- |
   `;
 
   Object.entries(options).forEach(([option, value]) => {
@@ -58,7 +63,7 @@ function generateOptionTable(options) {
       return;
     }
 
-    text += `\n| ${option} | ${makeType(value)} | ${value.description} |`;
+    text += `\n| ${option} | ${makeType(value)} | ${makeScope(value)} | ${value.description} |`;
   });
 
   return text;
@@ -82,7 +87,7 @@ async function generateConfigDocs() {
 
     \`@design-systems/cli\` supports a wide array of configuration files. 
     
-    Add one of the following to to the root of the project:
+    Add one of the following to to the root of the project and/or the root of a given submodule:
 
     - a \`ds\` key in the \`package.json\`
     - \`.dsrc\`
@@ -92,6 +97,8 @@ async function generateConfigDocs() {
     - \`.dsrc.js\`
     - \`ds.config.js\`
     - \`ds.config.json\`
+
+    !> The package-specific configuration feature is in very early stages, and only supports options with the **Local** scope.
 
     ## Structure
 

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -9,6 +9,8 @@ import { Overwrite } from 'utility-types';
 export type Option = AppOption & {
   /** Whether the Option should be configurable via ds.config.json */
   config?: boolean;
+  /** Whether or not the option is available in the global or local scope */
+  scope?: string;
 };
 
 interface Configurable {

--- a/plugins/size/package.json
+++ b/plugins/size/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@design-systems/cli-utils": "link:../../packages/cli-utils",
-    "@design-systems/load-config": "link:../../packages/load-config",
+    "cosmiconfig": "7.0.0",
     "@design-systems/plugin": "link:../../packages/plugin",
     "@royriojas/get-exports-from-file": "https://github.com/hipstersmoothie/get-exports-from-file#all",
     "change-case": "4.1.1",

--- a/plugins/size/package.json
+++ b/plugins/size/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@design-systems/cli-utils": "link:../../packages/cli-utils",
+    "@design-systems/load-config": "link:../../packages/load-config",
     "@design-systems/plugin": "link:../../packages/plugin",
     "@royriojas/get-exports-from-file": "https://github.com/hipstersmoothie/get-exports-from-file#all",
     "change-case": "4.1.1",
@@ -42,6 +43,7 @@
     "table": "6.0.7",
     "terser-webpack-plugin": "4.1.0",
     "tslib": "2.0.1",
+    "utility-types": "3.10.0",
     "webpack": "4.44.1",
     "webpack-bundle-analyzer": "3.8.0",
     "webpack-inject-plugin": "1.5.5",

--- a/plugins/size/src/command.ts
+++ b/plugins/size/src/command.ts
@@ -95,7 +95,7 @@ const command: CliCommand = {
       description: 'Size limit failure threshold',
       config: true,
       scope: 'Local'
-    }
+    },
     {
       name: 'merge-base',
       type: String,

--- a/plugins/size/src/command.ts
+++ b/plugins/size/src/command.ts
@@ -90,6 +90,13 @@ const command: CliCommand = {
       config: true
     },
     {
+      name: 'sizeLimit',
+      type: Number,
+      description: 'Size limit failure threshold',
+      config: true,
+      scope: 'Local'
+    }
+    {
       name: 'merge-base',
       type: String,
       description: 'Run the plugin against merge base. (Will be slower due to additional build process)'

--- a/plugins/size/src/index.ts
+++ b/plugins/size/src/index.ts
@@ -90,7 +90,7 @@ export default class SizePlugin implements Plugin<SizeArgs> {
     const underFailureThreshold = size &&
         size.percent <= FAILURE_THRESHOLD ||
         size.percent === Infinity;
-    const underSizeLimit = args.limit ? size.pr.js + size.pr.css <= args.limit : true;
+    const underSizeLimit = size.localBudget ? size.pr.js + size.pr.css <= size.localBudget : true;
     const success = underFailureThreshold && underSizeLimit;
 
     await reportResults(

--- a/plugins/size/src/index.ts
+++ b/plugins/size/src/index.ts
@@ -8,7 +8,7 @@ import {
   SizeResult} from "./interfaces"
 import { formatLine, formatExports } from "./utils/formatUtils";
 import { buildPackages } from "./utils/BuildUtils";
-import { calcSizeForAllPackages, reportResults, table, diffSizeForPackage } from "./utils/CalcSizeUtils";
+import { calcSizeForAllPackages, reportResults, table, diffSizeForPackage, sizePassesMuster } from "./utils/CalcSizeUtils";
 import { startAnalyze } from "./utils/WebpackUtils";
 import { createDiff } from "./utils/DiffUtils";
 
@@ -86,12 +86,7 @@ export default class SizePlugin implements Plugin<SizeArgs> {
       local
     });
     const header = args.css ? cssHeader : defaultHeader;
-
-    const underFailureThreshold = size &&
-        size.percent <= FAILURE_THRESHOLD ||
-        size.percent === Infinity;
-    const underSizeLimit = size.localBudget ? size.pr.js + size.pr.css <= size.localBudget : true;
-    const success = underFailureThreshold && underSizeLimit;
+    const success = sizePassesMuster(size, FAILURE_THRESHOLD);
 
     await reportResults(
       name,

--- a/plugins/size/src/index.ts
+++ b/plugins/size/src/index.ts
@@ -87,9 +87,15 @@ export default class SizePlugin implements Plugin<SizeArgs> {
     });
     const header = args.css ? cssHeader : defaultHeader;
 
+    const underFailureThreshold = size &&
+        size.percent <= FAILURE_THRESHOLD ||
+        size.percent === Infinity;
+    const underSizeLimit = args.limit ? size.pr.js + size.pr.css <= args.limit : true;
+    const success = underFailureThreshold && underSizeLimit;
+
     await reportResults(
       name,
-      size.percent <= FAILURE_THRESHOLD || size.percent === Infinity,
+      success,
       Boolean(args.comment),
       table(
         args.detailed
@@ -107,7 +113,7 @@ export default class SizePlugin implements Plugin<SizeArgs> {
       createDiff();
     }
 
-    if (size && size.percent > FAILURE_THRESHOLD && size.percent !== Infinity) {
+    if (!success) {
       process.exit(1);
     }
   }

--- a/plugins/size/src/interfaces.ts
+++ b/plugins/size/src/interfaces.ts
@@ -19,6 +19,8 @@ export interface SizeArgs {
   ignore?: string[]
   /** The registry to install packages from */
   registry?: string
+  /** Size limit failure threshold */
+  limit?: number
   /** Size Failure Threshold */
   failureThreshold?: number
   /** Run the plugin against merge base. (Will be slower due to additional build process) */

--- a/plugins/size/src/interfaces.ts
+++ b/plugins/size/src/interfaces.ts
@@ -20,7 +20,7 @@ export interface SizeArgs {
   /** The registry to install packages from */
   registry?: string
   /** Size limit failure threshold */
-  limit?: number
+  sizeLimit?: number
   /** Size Failure Threshold */
   failureThreshold?: number
   /** Run the plugin against merge base. (Will be slower due to additional build process) */
@@ -45,6 +45,8 @@ export interface Size {
   js: number
   /** Top level exports of package */
   exported?: Export[]
+  /** Maximum bundle size as defined by the package */
+  limit?: number
 }
 
 export interface SizeResult {
@@ -54,6 +56,8 @@ export interface SizeResult {
   pr: Size
   /** The difference between sizes */
   percent: number
+  /** The total number of bytes allowed as defined in the local changeset */
+  localBudget?: number
 }
 
 export interface ConfigOptions {

--- a/plugins/size/src/interfaces.ts
+++ b/plugins/size/src/interfaces.ts
@@ -90,6 +90,15 @@ export interface GetSizesOptions extends CommonCalcSizeOptions {
   analyze?: boolean
   /** What port to start the analyzer on */
   analyzerPort?: number
+  /** Working directory to execute analysis from */
+  dir: string
+}
+
+export interface LoadPackageOptions {
+  /** The name of the package to get size for */
+  name: string
+  /** The registry to install packages from */
+  registry?: string
 }
 
 type Scope = 'pr' | 'master'

--- a/plugins/size/src/utils/BuildUtils.ts
+++ b/plugins/size/src/utils/BuildUtils.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import { getMonorepoRoot, createLogger, getLogLevel } from '@design-systems/cli-utils';
 import { mockPackage } from './CalcSizeUtils';
-import { GetSizesOptions, CommonOptions } from '../interfaces';
+import { LoadPackageOptions } from '../interfaces';
 
 const logger = createLogger({ scope: 'size' });
 
@@ -59,7 +59,7 @@ export function getLocalPackage(
 }
 
 /** Install package to tmp dir */
-export async function loadPackage(options: GetSizesOptions & CommonOptions) {
+export async function loadPackage(options: LoadPackageOptions) {
   const dir = mockPackage();
   const execOptions: ExecSyncOptions = {
     cwd: dir,

--- a/plugins/size/src/utils/BuildUtils.ts
+++ b/plugins/size/src/utils/BuildUtils.ts
@@ -1,7 +1,10 @@
-import { execSync } from 'child_process';
+import { execSync, ExecSyncOptions } from 'child_process';
 import os from 'os';
 import path from 'path';
-import { getMonorepoRoot, createLogger } from '@design-systems/cli-utils';
+import fs from 'fs-extra';
+import { getMonorepoRoot, createLogger, getLogLevel } from '@design-systems/cli-utils';
+import { mockPackage } from './CalcSizeUtils';
+import { GetSizesOptions, CommonOptions } from '../interfaces';
 
 const logger = createLogger({ scope: 'size' });
 
@@ -53,4 +56,40 @@ export function getLocalPackage(
   }
 
   return path.join(local, path.relative(getMonorepoRoot(), pkg.location));
+}
+
+/** Install package to tmp dir */
+export async function loadPackage(options: GetSizesOptions & CommonOptions) {
+  const dir = mockPackage();
+  const execOptions: ExecSyncOptions = {
+    cwd: dir,
+    stdio: getLogLevel() === 'trace' ? 'inherit' : 'ignore'
+  };
+  try {
+    const browsersList = path.join(getMonorepoRoot(), '.browserslistrc');
+    if (fs.existsSync(browsersList)) {
+      fs.copyFileSync(browsersList, path.join(dir, '.browserslistrc'));
+    }
+
+    const npmrc = path.join(getMonorepoRoot(), '.npmrc');
+    if (options.registry && fs.existsSync(npmrc)) {
+      fs.copyFileSync(npmrc, path.join(dir, '.npmrc'));
+    }
+
+    logger.debug(`Installing: ${options.name}`);
+    if (options.registry) {
+      execSync(
+        `yarn add ${options.name} --registry ${options.registry}`,
+        execOptions
+      );
+    } else {
+      execSync(`yarn add ${options.name}`, execOptions);
+    }
+  } catch (error) {
+    logger.debug(error);
+    logger.warn(`Could not find package ${options.name}...`);
+    return [];
+  }
+
+  return dir;
 }

--- a/plugins/size/src/utils/BuildUtils.ts
+++ b/plugins/size/src/utils/BuildUtils.ts
@@ -14,7 +14,7 @@ export function buildPackages(args: {
   mergeBase: string
   /** Build command for merge base */
   buildCommand: string
-}) {
+}): string {
   const id = Math.random().toString(36).substring(7);
   const dir = path.join(os.tmpdir(), `commit-build-${id}`);
   const root = getMonorepoRoot();
@@ -59,7 +59,7 @@ export function getLocalPackage(
 }
 
 /** Install package to tmp dir */
-export async function loadPackage(options: LoadPackageOptions) {
+export async function loadPackage(options: LoadPackageOptions): Promise<string> {
   const dir = mockPackage();
   const execOptions: ExecSyncOptions = {
     cwd: dir,
@@ -88,7 +88,7 @@ export async function loadPackage(options: LoadPackageOptions) {
   } catch (error) {
     logger.debug(error);
     logger.warn(`Could not find package ${options.name}...`);
-    return [];
+    return './';
   }
 
   return dir;

--- a/plugins/size/src/utils/CalcSizeUtils.ts
+++ b/plugins/size/src/utils/CalcSizeUtils.ts
@@ -82,7 +82,8 @@ async function calcSizeForPackage({
     registry,
     dir
   });
-  const packageConfig = loadConfig(path.join(dir, 'node_modules', packageName));
+  const packageDir = local ? path.join(dir, 'node_modules', packageName) : name;
+  const packageConfig = loadConfig(packageDir);
   fs.removeSync(dir);
 
   const js = sizes.filter((size) => !size.chunkNames.includes('css'));

--- a/plugins/size/src/utils/CalcSizeUtils.ts
+++ b/plugins/size/src/utils/CalcSizeUtils.ts
@@ -40,6 +40,7 @@ const cssHeader = [
 
 const defaultHeader = ['master', 'pr', '+/-', '%'];
 
+/** Load package-specific configuration options. */
 function loadConfig(cwd: string) {
   return load('ds', {
     searchPlaces: [

--- a/plugins/size/src/utils/CalcSizeUtils.ts
+++ b/plugins/size/src/utils/CalcSizeUtils.ts
@@ -146,7 +146,7 @@ async function diffSizeForPackage({
 }
 
 /** Create a mock npm package in a tmp dir on the system. */
-export function mockPackage() {
+export function mockPackage(): string {
   const id = Math.random().toString(36).substring(7);
   const dir = path.join(os.tmpdir(), `package-size-${id}`);
 

--- a/plugins/size/src/utils/CalcSizeUtils.ts
+++ b/plugins/size/src/utils/CalcSizeUtils.ts
@@ -1,5 +1,5 @@
 import { monorepoName, createLogger } from '@design-systems/cli-utils';
-import { loadConfig } from '@design-systems/load-config';
+import { cosmiconfigSync as load } from 'cosmiconfig';
 import path from 'path';
 import fs from 'fs-extra';
 import os from 'os';
@@ -40,6 +40,21 @@ const cssHeader = [
 
 const defaultHeader = ['master', 'pr', '+/-', '%'];
 
+function loadConfig(cwd: string) {
+  return load('ds', {
+    searchPlaces: [
+      'package.json',
+      `.dsrc`,
+      `.dsrc.json`,
+      `.dsrc.yaml`,
+      `.dsrc.yml`,
+      `.dsrc.js`,
+      `ds.config.js`,
+      `ds.config.json`,
+    ]
+  }).search(cwd)?.config;
+}
+
 /** Calculate the bundled CSS and JS size. */
 async function calcSizeForPackage({
   name,
@@ -66,9 +81,7 @@ async function calcSizeForPackage({
     registry,
     dir
   });
-  const packageConfig = loadConfig({
-    cwd: path.join(dir, 'node_modules', packageName)
-  });
+  const packageConfig = loadConfig(path.join(dir, 'node_modules', packageName));
   fs.removeSync(dir);
 
   const js = sizes.filter((size) => !size.chunkNames.includes('css'));

--- a/plugins/size/src/utils/CalcSizeUtils.ts
+++ b/plugins/size/src/utils/CalcSizeUtils.ts
@@ -1,4 +1,5 @@
 import { monorepoName, createLogger } from '@design-systems/cli-utils';
+import { loadConfig } from '@design-systems/load-config';
 import path from 'path';
 import fs from 'fs-extra';
 import os from 'os';
@@ -65,6 +66,9 @@ async function calcSizeForPackage({
     registry,
     dir
   });
+  const packageConfig = loadConfig({
+    cwd: path.join(dir, 'node_modules', packageName)
+  });
   fs.removeSync(dir);
 
   const js = sizes.filter((size) => !size.chunkNames.includes('css'));
@@ -83,6 +87,7 @@ async function calcSizeForPackage({
     js: js.length ? js.reduce((acc, i) => i.size + acc, 0) - RUNTIME_SIZE : 0, // Minus webpack runtime size;
     css: css.length ? css.reduce((acc, i) => i.size + acc, 0) : 0,
     exported: sizes,
+    limit: packageConfig?.size?.sizeLimit
   };
 }
 
@@ -136,6 +141,7 @@ async function diffSizeForPackage({
     master,
     pr,
     percent,
+    localBudget: pr.limit
   };
 }
 

--- a/plugins/size/src/utils/CalcSizeUtils.ts
+++ b/plugins/size/src/utils/CalcSizeUtils.ts
@@ -20,7 +20,7 @@ import {
   DiffSizeForPackageOptions
 } from '../interfaces';
 import { getSizes } from './WebpackUtils';
-import { getLocalPackage } from './BuildUtils';
+import { getLocalPackage, loadPackage } from './BuildUtils';
 
 const RUNTIME_SIZE = 537;
 
@@ -50,15 +50,22 @@ async function calcSizeForPackage({
   registry,
   local
 }: CommonOptions & CommonCalcSizeOptions): Promise<Size> {
+  const packageName = local ? getLocalPackage(importName, local) : name;
+  const dir = await loadPackage({
+    name: packageName,
+    registry
+  });
   const sizes = await getSizes({
-    name: local ? getLocalPackage(importName, local) : name,
+    name: packageName,
     importName,
     scope,
     persist,
     chunkByExport,
     diff,
-    registry
+    registry,
+    dir
   });
+  fs.removeSync(dir);
 
   const js = sizes.filter((size) => !size.chunkNames.includes('css'));
   const css = sizes.filter((size) => size.chunkNames.includes('css'));

--- a/plugins/size/src/utils/WebpackUtils.ts
+++ b/plugins/size/src/utils/WebpackUtils.ts
@@ -159,7 +159,7 @@ async function runWebpack(config: webpack.Configuration): Promise<webpack.Stats>
   });
 }
 
-/** Install package to tmp dir and run webpack on it to calculate size. */
+/** Run webpack on package directory to calculate size. */
 async function getSizes(options: GetSizesOptions & CommonOptions) {
   const result = await runWebpack(
     await config(options)

--- a/plugins/size/src/utils/WebpackUtils.ts
+++ b/plugins/size/src/utils/WebpackUtils.ts
@@ -9,13 +9,11 @@ import Terser from 'terser-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import OptimizeCSSAssetsPlugin from 'optimize-css-assets-webpack-plugin';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
-import { getMonorepoRoot, getLogLevel } from '@design-systems/cli-utils';
-import { execSync, ExecSyncOptions } from 'child_process';
+import { execSync } from 'child_process';
 import RelativeCommentsPlugin from '../RelativeCommentsPlugin';
 import { fromEntries } from './formatUtils';
 import { ConfigOptions, GetSizesOptions, CommonOptions } from '../interfaces';
-import { mockPackage } from './CalcSizeUtils';
-import { getLocalPackage } from './BuildUtils';
+import { getLocalPackage, loadPackage } from './BuildUtils';
 
 const logger = createLogger({ scope: 'size' });
 
@@ -163,37 +161,7 @@ async function runWebpack(config: webpack.Configuration): Promise<webpack.Stats>
 
 /** Install package to tmp dir and run webpack on it to calculate size. */
 async function getSizes(options: GetSizesOptions & CommonOptions) {
-  const dir = mockPackage();
-  const execOptions: ExecSyncOptions = {
-    cwd: dir,
-    stdio: getLogLevel() === 'trace' ? 'inherit' : 'ignore'
-  };
-  try {
-    const browsersList = path.join(getMonorepoRoot(), '.browserslistrc');
-    if (fs.existsSync(browsersList)) {
-      fs.copyFileSync(browsersList, path.join(dir, '.browserslistrc'));
-    }
-
-    const npmrc = path.join(getMonorepoRoot(), '.npmrc');
-    if (options.registry && fs.existsSync(npmrc)) {
-      fs.copyFileSync(npmrc, path.join(dir, '.npmrc'));
-    }
-
-    logger.debug(`Installing: ${options.name}`);
-    if (options.registry) {
-      execSync(
-        `yarn add ${options.name} --registry ${options.registry}`,
-        execOptions
-      );
-    } else {
-      execSync(`yarn add ${options.name}`, execOptions);
-    }
-  } catch (error) {
-    logger.debug(error);
-    logger.warn(`Could not find package ${options.name}...`);
-    return [];
-  }
-
+  const dir = await loadPackage(options);
   const result = await runWebpack(
     await config({
       dir,


### PR DESCRIPTION
# What Changed

fixes #690 

Adds a new option for `ds size` that enables enforcement of a limit on component bundles. Refactors the `size` plugin significantly in order to support locally-scoped configuration options, namely, the `sizeLimit` option.

# Why

I'm building a new Design System component and want to enforce a limit on the component as a whole, rather than simply on incoming changesets

Todo:

- [ ] Add tests
    - Tests don't exist for this already, so it's unclear to me how/if to try to add any
- [ ] Add docs
    - Looks like docs all exist in the `gh-pages` branch. What's the process for adding to that? Just a separate PR to `gh-pages`?

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.14.1--canary.691.19342.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@4.14.1--canary.691.19342.0
  npm install @design-systems/babel-plugin-replace-styles@4.14.1--canary.691.19342.0
  npm install @design-systems/cli-utils@4.14.1--canary.691.19342.0
  npm install @design-systems/cli@4.14.1--canary.691.19342.0
  npm install @design-systems/core@4.14.1--canary.691.19342.0
  npm install @design-systems/create@4.14.1--canary.691.19342.0
  npm install @design-systems/docs@4.14.1--canary.691.19342.0
  npm install @design-systems/eslint-config@4.14.1--canary.691.19342.0
  npm install @design-systems/hooks@4.14.1--canary.691.19342.0
  npm install @design-systems/load-config@4.14.1--canary.691.19342.0
  npm install @design-systems/next-esm-css@4.14.1--canary.691.19342.0
  npm install @design-systems/plugin@4.14.1--canary.691.19342.0
  npm install @design-systems/stylelint-config@4.14.1--canary.691.19342.0
  npm install @design-systems/svg-icon-builder@4.14.1--canary.691.19342.0
  npm install @design-systems/utils@4.14.1--canary.691.19342.0
  npm install @design-systems/build@4.14.1--canary.691.19342.0
  npm install @design-systems/bundle@4.14.1--canary.691.19342.0
  npm install @design-systems/clean@4.14.1--canary.691.19342.0
  npm install @design-systems/create-command@4.14.1--canary.691.19342.0
  npm install @design-systems/dev@4.14.1--canary.691.19342.0
  npm install @design-systems/lint@4.14.1--canary.691.19342.0
  npm install @design-systems/playroom@4.14.1--canary.691.19342.0
  npm install @design-systems/proof@4.14.1--canary.691.19342.0
  npm install @design-systems/size@4.14.1--canary.691.19342.0
  npm install @design-systems/storybook@4.14.1--canary.691.19342.0
  npm install @design-systems/test@4.14.1--canary.691.19342.0
  npm install @design-systems/update@4.14.1--canary.691.19342.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@4.14.1--canary.691.19342.0
  yarn add @design-systems/babel-plugin-replace-styles@4.14.1--canary.691.19342.0
  yarn add @design-systems/cli-utils@4.14.1--canary.691.19342.0
  yarn add @design-systems/cli@4.14.1--canary.691.19342.0
  yarn add @design-systems/core@4.14.1--canary.691.19342.0
  yarn add @design-systems/create@4.14.1--canary.691.19342.0
  yarn add @design-systems/docs@4.14.1--canary.691.19342.0
  yarn add @design-systems/eslint-config@4.14.1--canary.691.19342.0
  yarn add @design-systems/hooks@4.14.1--canary.691.19342.0
  yarn add @design-systems/load-config@4.14.1--canary.691.19342.0
  yarn add @design-systems/next-esm-css@4.14.1--canary.691.19342.0
  yarn add @design-systems/plugin@4.14.1--canary.691.19342.0
  yarn add @design-systems/stylelint-config@4.14.1--canary.691.19342.0
  yarn add @design-systems/svg-icon-builder@4.14.1--canary.691.19342.0
  yarn add @design-systems/utils@4.14.1--canary.691.19342.0
  yarn add @design-systems/build@4.14.1--canary.691.19342.0
  yarn add @design-systems/bundle@4.14.1--canary.691.19342.0
  yarn add @design-systems/clean@4.14.1--canary.691.19342.0
  yarn add @design-systems/create-command@4.14.1--canary.691.19342.0
  yarn add @design-systems/dev@4.14.1--canary.691.19342.0
  yarn add @design-systems/lint@4.14.1--canary.691.19342.0
  yarn add @design-systems/playroom@4.14.1--canary.691.19342.0
  yarn add @design-systems/proof@4.14.1--canary.691.19342.0
  yarn add @design-systems/size@4.14.1--canary.691.19342.0
  yarn add @design-systems/storybook@4.14.1--canary.691.19342.0
  yarn add @design-systems/test@4.14.1--canary.691.19342.0
  yarn add @design-systems/update@4.14.1--canary.691.19342.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
