### PR TITLE
Remove `peerDependency` on `@types/react`

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,7 +32,6 @@
     "react-merge-refs": "^1.0.0"
   },
   "peerDependencies": {
-    "@types/react": "*",
     "react": ">= 16.8.6",
     "react-dom": ">= 16.8.6"
   },


### PR DESCRIPTION
# What Changed

Remove `peerDependency` on `@types/react`

# Why

Anything transitively using `@design-systems/utils` such as any project using Storybook must include `@types/react` in their `package.json` when using `pnpm`