### PR TITLE
fix esm css.js output

### DIFF
--- a/plugins/build/src/configs/postcss.config.ts
+++ b/plugins/build/src/configs/postcss.config.ts
@@ -56,11 +56,10 @@ module.exports = function (ctx: PostCSSContext = { outDir: 'dist' }) {
           if (outputFileName) {
             const cjs = `${outputFileName.replace('dist', 'dist/cjs')}.js`;
             const esm = `${outputFileName.replace('dist', 'dist/esm')}.js`;
-            const code = `module.exports = ${JSON.stringify(json)};`;
 
             return Promise.all([
-              fs.outputFile(cjs, code),
-              fs.outputFile(esm, code),
+              fs.outputFile(cjs, `module.exports = ${JSON.stringify(json)};`),
+              fs.outputFile(esm, `export default ${JSON.stringify(json)};`),
             ]);
           }
         },


### PR DESCRIPTION
# What Changed

Previously we were outputting cjs code to the esm files

# Why

I was trying to use code output by this tool in vite and the imports for css were breaking the build.



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.15.2--canary.709.19992.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@4.15.2--canary.709.19992.0
  npm install @design-systems/babel-plugin-replace-styles@4.15.2--canary.709.19992.0
  npm install @design-systems/cli-utils@4.15.2--canary.709.19992.0
  npm install @design-systems/cli@4.15.2--canary.709.19992.0
  npm install @design-systems/core@4.15.2--canary.709.19992.0
  npm install @design-systems/create@4.15.2--canary.709.19992.0
  npm install @design-systems/eslint-config@4.15.2--canary.709.19992.0
  npm install @design-systems/hooks@4.15.2--canary.709.19992.0
  npm install @design-systems/load-config@4.15.2--canary.709.19992.0
  npm install @design-systems/next-esm-css@4.15.2--canary.709.19992.0
  npm install @design-systems/plugin@4.15.2--canary.709.19992.0
  npm install @design-systems/stylelint-config@4.15.2--canary.709.19992.0
  npm install @design-systems/svg-icon-builder@4.15.2--canary.709.19992.0
  npm install @design-systems/utils@4.15.2--canary.709.19992.0
  npm install @design-systems/build@4.15.2--canary.709.19992.0
  npm install @design-systems/bundle@4.15.2--canary.709.19992.0
  npm install @design-systems/clean@4.15.2--canary.709.19992.0
  npm install @design-systems/create-command@4.15.2--canary.709.19992.0
  npm install @design-systems/dev@4.15.2--canary.709.19992.0
  npm install @design-systems/lint@4.15.2--canary.709.19992.0
  npm install @design-systems/playroom@4.15.2--canary.709.19992.0
  npm install @design-systems/proof@4.15.2--canary.709.19992.0
  npm install @design-systems/size@4.15.2--canary.709.19992.0
  npm install @design-systems/storybook@4.15.2--canary.709.19992.0
  npm install @design-systems/test@4.15.2--canary.709.19992.0
  npm install @design-systems/update@4.15.2--canary.709.19992.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@4.15.2--canary.709.19992.0
  yarn add @design-systems/babel-plugin-replace-styles@4.15.2--canary.709.19992.0
  yarn add @design-systems/cli-utils@4.15.2--canary.709.19992.0
  yarn add @design-systems/cli@4.15.2--canary.709.19992.0
  yarn add @design-systems/core@4.15.2--canary.709.19992.0
  yarn add @design-systems/create@4.15.2--canary.709.19992.0
  yarn add @design-systems/eslint-config@4.15.2--canary.709.19992.0
  yarn add @design-systems/hooks@4.15.2--canary.709.19992.0
  yarn add @design-systems/load-config@4.15.2--canary.709.19992.0
  yarn add @design-systems/next-esm-css@4.15.2--canary.709.19992.0
  yarn add @design-systems/plugin@4.15.2--canary.709.19992.0
  yarn add @design-systems/stylelint-config@4.15.2--canary.709.19992.0
  yarn add @design-systems/svg-icon-builder@4.15.2--canary.709.19992.0
  yarn add @design-systems/utils@4.15.2--canary.709.19992.0
  yarn add @design-systems/build@4.15.2--canary.709.19992.0
  yarn add @design-systems/bundle@4.15.2--canary.709.19992.0
  yarn add @design-systems/clean@4.15.2--canary.709.19992.0
  yarn add @design-systems/create-command@4.15.2--canary.709.19992.0
  yarn add @design-systems/dev@4.15.2--canary.709.19992.0
  yarn add @design-systems/lint@4.15.2--canary.709.19992.0
  yarn add @design-systems/playroom@4.15.2--canary.709.19992.0
  yarn add @design-systems/proof@4.15.2--canary.709.19992.0
  yarn add @design-systems/size@4.15.2--canary.709.19992.0
  yarn add @design-systems/storybook@4.15.2--canary.709.19992.0
  yarn add @design-systems/test@4.15.2--canary.709.19992.0
  yarn add @design-systems/update@4.15.2--canary.709.19992.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
