### PR TITLE
fix: update CI node minor version for linters bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/design-systems-cli
   docker:
-    - image: circleci/node:16.5.0-browsers
+    - image: circleci/node:16.10.0-browsers
   environment:
     TZ: '/usr/share/zoneinfo/America/Los_Angeles'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/design-systems-cli
   docker:
-    - image: circleci/node:16.20.2-browsers
+    - image: cimg/node:16.20.2-browsers
   environment:
     TZ: '/usr/share/zoneinfo/America/Los_Angeles'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/design-systems-cli
   docker:
-    - image: circleci/node:16.10.0-browsers
+    - image: circleci/node:16.20.2-browsers
   environment:
     TZ: '/usr/share/zoneinfo/America/Los_Angeles'
 


### PR DESCRIPTION
# What Changed

Updates CircleCI to use node image from `16.5.0-browsers`  -> `16.20.2-browsers`

Contains the same changes as #468 but also updates CI to make it pass

# Why

Linters update specifies engine node `">=16.14.0"`
