### PR TITLE
fix: test script does not fire exit code

### DIFF
--- a/plugins/test/src/index.ts
+++ b/plugins/test/src/index.ts
@@ -55,7 +55,7 @@ export default class TestPlugin implements Plugin<TestArgs> {
         await createJestAnnotations(results);
       }
 
-      if (results.numFailedTests > 0) {
+      if (!results.success) {
         process.exit(1);
       }
     } catch (e) {


### PR DESCRIPTION
# What Changed
Updated `ds test` script so it fires the correct exit code when the test fails. 

# Why
A non-zero exit code should be fired whenever the jest test is not successful. Previously, the code only checked "numFailedTests > 0", which does not cover other scenarios such as "numFailedTestSuites" and "numRuntimeErrorTestSuites". 

This is an issue for consumers that rely on the exit code. For example, CICD will pass event hen the test suite fails to run.

Todo:

- [ ] Add tests
- [ ] Add docs
