### PR TITLE
BREAKING CHANGE: enforce code coverage and test suite failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/**
+
 # These files are generated
 packages/docs/src/generated
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Ensure you have the following softwares installed:
 * `Node >= 10.18.1` - [Installation guide](https://nodejs.org/en/download/)
 * `Yarn` - [Installation guide](https://classic.yarnpkg.com/en/docs/install)
 
+If node-gyp throws errors during installation, installation may still be successful
+
 ### To get started:
 
 To get set up, fork and clone the project then run the following command:

--- a/plugins/test/src/index.ts
+++ b/plugins/test/src/index.ts
@@ -55,7 +55,7 @@ export default class TestPlugin implements Plugin<TestArgs> {
         await createJestAnnotations(results);
       }
 
-      if (results.numFailedTests > 0) {
+      if (!results.success) {
         process.exit(1);
       }
     } catch (e) {


### PR DESCRIPTION
Background: code coverage just doesn't work with ds cli, as far as I can tell. Also, if test suites
fail completely, that is disregarded in terms of deciding what the bash exit code is. For example,
if 10 suites run and they all fail before Jest realizes that they contain tests, the test run is
currently still considered a success.

About this fix:
runCLI is an undocumented API. Hence this is not even the right fix. 
The right fix would be to stop using an undocumented API, and instead use Jest as it was designed,
which I think means via shell script. I'm not pursuing that, out
of time constraints, but I see it as far superior. Using
undocumented features makes it more likely that they will be used
incorrectly (as was being done here.). Also -- why wasn't this
ever tested to see that it worked? Maybe I'm missing something
super obvious here :| .

I did not rely on any documentation for this fix, because there
are no official docs, but it seems like this is the right solution,
and it was very easy to test.

This is a breaking change because any repo which is using ds-cli
and ignoring code coverage -- probably most of them -- will stop
working once this change is made. If ds-cli were not in use by anyone,
I would call it a patch update, but as it is, this instantly breaks
any consumers that think their coverage is working and never looked
at their logs. So I think a major version update is warranted, as
a warning.

Also, ignored IntelliJ files, and updated readme to re-specify that
node-gyp errors can sometimes can be ignored, even when node-gyp
itself gives no indications that that is the case ("it works if it
ends with ok" -- but node-gyp output seems not end with ok for me).

## Test Cases

- "yarn start" does not throw
- When a repo fails code coverage, the command "ds test" exits with a non-zero exit code
- When a repo has a failing test, the command "ds test" exits with a non-zero exit code
- When a repo had adequate code coverage and no failing tests, the command "ds test" exits with a zero error code