### PR TITLE
BREAKING CHANGE: enforce code coverage and test suite failures 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/**
+
 # These files are generated
 packages/docs/src/generated
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Ensure you have the following softwares installed:
 * `Node >= 10.18.1` - [Installation guide](https://nodejs.org/en/download/)
 * `Yarn` - [Installation guide](https://classic.yarnpkg.com/en/docs/install)
 
+If node-gyp throws errors during installation, installation may still be successful
+
 ### To get started:
 
 To get set up, fork and clone the project then run the following command:

--- a/plugins/test/src/index.ts
+++ b/plugins/test/src/index.ts
@@ -55,7 +55,7 @@ export default class TestPlugin implements Plugin<TestArgs> {
         await createJestAnnotations(results);
       }
 
-      if (results.numFailedTests > 0) {
+      if (!results.success) {
         process.exit(1);
       }
     } catch (e) {


### PR DESCRIPTION


Background: code coverage just doesn't work with ds cli, as far as I can tell. Also, if test suites
fail completely, that is disregarded in terms of deciding what the bash exit code is. For example,
if 10 suites run and they all fail before Jest realizes that they contain tests, the test run is
currently still considered a success.

About this fix:
runCLI is an undocumented API. Hence this is not even the right fix.
The right fix would be to stop using an undocumented API, and instead use Jest as it was designed,
which I think means via shell script. I'm not pursuing that, out
of time constraints, but I see it as far superior. Using
undocumented features makes it more likely that they will be used
incorrectly (as was being done here.). Also -- why wasn't this
ever tested to see that it worked? Maybe I'm missing something
super obvious here :| .

I did not rely on any documentation for this fix, because there
are no official docs, but it seems like this is the right solution,
and it was very easy to test.

This is a breaking change because any repo which is using ds-cli
and ignoring code coverage -- probably most of them -- will stop
working once this change is made. If ds-cli were not in use by anyone,
I would call it a patch update, but as it is, this instantly breaks
any consumers that think their coverage is working and never looked
at their logs. So I think a major version update is warranted, as
a warning.

Also, ignored IntelliJ files, and updated readme to re-specify that
node-gyp errors can sometimes can be ignored, even when node-gyp
itself gives no indications that that is the case ("it works if it
ends with ok" -- but node-gyp output seems not end with ok for me).

## Test Cases

-"yarn start" does not throw
-When a repo fails code coverage, the command "ds test" exits with a non-zero exit code
-When a repo has a failing test, the command "ds test" exits with a non-zero exit code
-When a repo had adequate code coverage and no failing tests, the command "ds test" exits with a zero error code


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.0.0--canary.729.20738.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @design-systems/babel-plugin-include-styles@5.0.0--canary.729.20738.0
  npm install @design-systems/babel-plugin-replace-styles@5.0.0--canary.729.20738.0
  npm install @design-systems/cli-utils@5.0.0--canary.729.20738.0
  npm install @design-systems/cli@5.0.0--canary.729.20738.0
  npm install @design-systems/core@5.0.0--canary.729.20738.0
  npm install @design-systems/create@5.0.0--canary.729.20738.0
  npm install @design-systems/eslint-config@5.0.0--canary.729.20738.0
  npm install @design-systems/hooks@5.0.0--canary.729.20738.0
  npm install @design-systems/load-config@5.0.0--canary.729.20738.0
  npm install @design-systems/next-esm-css@5.0.0--canary.729.20738.0
  npm install @design-systems/plugin@5.0.0--canary.729.20738.0
  npm install @design-systems/stylelint-config@5.0.0--canary.729.20738.0
  npm install @design-systems/svg-icon-builder@5.0.0--canary.729.20738.0
  npm install @design-systems/utils@5.0.0--canary.729.20738.0
  npm install @design-systems/build@5.0.0--canary.729.20738.0
  npm install @design-systems/bundle@5.0.0--canary.729.20738.0
  npm install @design-systems/clean@5.0.0--canary.729.20738.0
  npm install @design-systems/create-command@5.0.0--canary.729.20738.0
  npm install @design-systems/dev@5.0.0--canary.729.20738.0
  npm install @design-systems/lint@5.0.0--canary.729.20738.0
  npm install @design-systems/playroom@5.0.0--canary.729.20738.0
  npm install @design-systems/proof@5.0.0--canary.729.20738.0
  npm install @design-systems/size@5.0.0--canary.729.20738.0
  npm install @design-systems/storybook@5.0.0--canary.729.20738.0
  npm install @design-systems/test@5.0.0--canary.729.20738.0
  npm install @design-systems/update@5.0.0--canary.729.20738.0
  # or 
  yarn add @design-systems/babel-plugin-include-styles@5.0.0--canary.729.20738.0
  yarn add @design-systems/babel-plugin-replace-styles@5.0.0--canary.729.20738.0
  yarn add @design-systems/cli-utils@5.0.0--canary.729.20738.0
  yarn add @design-systems/cli@5.0.0--canary.729.20738.0
  yarn add @design-systems/core@5.0.0--canary.729.20738.0
  yarn add @design-systems/create@5.0.0--canary.729.20738.0
  yarn add @design-systems/eslint-config@5.0.0--canary.729.20738.0
  yarn add @design-systems/hooks@5.0.0--canary.729.20738.0
  yarn add @design-systems/load-config@5.0.0--canary.729.20738.0
  yarn add @design-systems/next-esm-css@5.0.0--canary.729.20738.0
  yarn add @design-systems/plugin@5.0.0--canary.729.20738.0
  yarn add @design-systems/stylelint-config@5.0.0--canary.729.20738.0
  yarn add @design-systems/svg-icon-builder@5.0.0--canary.729.20738.0
  yarn add @design-systems/utils@5.0.0--canary.729.20738.0
  yarn add @design-systems/build@5.0.0--canary.729.20738.0
  yarn add @design-systems/bundle@5.0.0--canary.729.20738.0
  yarn add @design-systems/clean@5.0.0--canary.729.20738.0
  yarn add @design-systems/create-command@5.0.0--canary.729.20738.0
  yarn add @design-systems/dev@5.0.0--canary.729.20738.0
  yarn add @design-systems/lint@5.0.0--canary.729.20738.0
  yarn add @design-systems/playroom@5.0.0--canary.729.20738.0
  yarn add @design-systems/proof@5.0.0--canary.729.20738.0
  yarn add @design-systems/size@5.0.0--canary.729.20738.0
  yarn add @design-systems/storybook@5.0.0--canary.729.20738.0
  yarn add @design-systems/test@5.0.0--canary.729.20738.0
  yarn add @design-systems/update@5.0.0--canary.729.20738.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
